### PR TITLE
Build the right LinuxKit version

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -10,11 +10,38 @@ in
       sha256 = "0g2j41cx2w2an5d9kkqvgmada7ssdxqz1zvjd7hi5vif8ag0v5la";
     }) { }
 }:
+with pkgs;
+let
+  linuxkit = buildGoPackage rec {
+    pname = "linuxkit";
+    version = "1ec1768d18ad7a5cd2d6e5c2125a14324ff6f57f";
 
-pkgs.mkShell {
+    goPackagePath = "github.com/linuxkit/linuxkit";
+
+    src = fetchFromGitHub {
+      owner = "linuxkit";
+      repo = "linuxkit";
+      rev = "1ec1768d18ad7a5cd2d6e5c2125a14324ff6f57f";
+      sha256 = "09qap7bfssbbqhrvjqpplahpldci956lbfdwxy9nwzml3aw18r42";
+    };
+
+    subPackages = [ "src/cmd/linuxkit" ];
+
+    buildFlagsArray = [ "-ldflags=-s -w -X ${goPackagePath}/src/cmd/linuxkit/version.GitCommit=${src.rev} -X ${goPackagePath}/src/cmd/linuxkit/version.Version=${version}" ];
+
+    meta = with lib; {
+      description = "A toolkit for building secure, portable and lean operating systems for containers";
+      license = licenses.asl20;
+      homepage = "https://github.com/linuxkit/linuxkit";
+      maintainers = [ maintainers.nicknovitski ];
+      platforms = platforms.unix;
+    };
+  };
+in
+mkShell {
   buildInputs = [
-    pkgs.git
-    pkgs.linuxkit
+    git
+    linuxkit
   ];
   shellHook =
     ''


### PR DESCRIPTION
Probably there is a better way but this one works. Now Nix installs the
right version of LinuxKit (v0.8 the one it installed originally does not
support build -docker flag)