### PR TITLE
Bootstrap release workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 out
+dist
+noname-*.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
+GIT_VERSION ?= $(shell git log -1 --format="%h")
+ifneq ($(shell git status --porcelain),)
+  GIT_VERSION := $(GIT_VERSION)-dirty
+endif
 default: bootkitBuild tink-dockerBuild image
+
 
 image:
 	mkdir -p out
@@ -18,3 +23,10 @@ convert:
 	cp out/imho-initrd.img ./convert/initrd.gz
 	cd convert; gunzip ./initrd.gz; cpio -idv < initrd; rm initrd; find . -print0 | cpio --null -ov --format=newc > ../initramfs; gzip ../initramfs
 
+dist: default convert
+	rm -rf ./dist ./convert
+	mkdir ./dist
+	mv ./initramfs.gz ./dist/initramfs-x86_64
+	mv ./out/imho-kernel ./dist/vmlinuz-x86_64
+	rm -rf out
+	cd ./dist && tar -czvf ../noname-${GIT_VERSION}.tar.gz ./*

--- a/README.md
+++ b/README.md
@@ -1,5 +1,66 @@
-Build init ramdisk and kernel (output directory ./out)
+## How to use noname with Sandbox
+
+[sandbox](https://github.com/tinkerbell/sandbox) is a project that helps you to
+create and run the Tinkerbell stack locally with Vagrant, on Equinix Metal with
+Terraform and it acts as a guide to deploy Tinkerbell wherever you like. I will
+tell you how you can change the default operating system installer environment
+called [OSIE](https://github.com/tinkerbell/osie) with this project.
+
+There are essentially two methods a manual one and a more automatic one. Have a
+look at the manual one even if you intent to use the automatic one just to learn
+what what the automation does for you.
+
+### The manual way
+
+When you start sandbox in vagrant for example as part of the provisioning step
+for the provisioner machine the `setup.sh` script gets executed. The script does
+a bunch of things the one we care here is the `setup_osie` function. In practice
+it creates the folder: `sandbox/deploy/state/webroot/misc/osie/current`. If you
+ran sandbox you already have that directory. `current` is the location that
+serves the operating system installation environment that runs inside a worker
+machine. You can even move or delete that directory because we have to replace
+it with the release package containing the new operating system. After you have
+removed the directory it is time to re-create it:
 
 ```
-make
+mkdir current
 ```
+
+Download the new tar.gz
+
+```
+wget http://s.gianarb.it/noname/noname-master.tar.gz
+```
+
+Uncompress it
+
+```
+tar xzcv -O ./current noname-master.tar.gz
+```
+
+Now you are ready to boot the worker, it will pick up the new operating system
+installation environment.
+
+
+### The automation way
+
+Sandbox has a file called
+[current_versions.sh](https://github.com/tinkerbell/sandbox/blob/master/current_versions.sh).
+If you change `OSIE_DOWNLOAD_LINK` with the noname link the setup.sh script will
+download the OS again and it will uncompress it in the right location
+(only if ./deploy/state/webroot/misc/osie/current does not exist)
+
+## Package a release
+
+```
+make dist
+```
+The `dist` make target will do a couple of things:
+
+1. Build the required docker images using `docker
+buildx`.
+2. It will use `linuxkit build` to prepare the init ramdisk and the
+kernel.
+3. It will convert the init ramkdisk in the right format that iPXE can boot
+4. It will create a `tar.gz` archive in the root of the project containing all
+   the files in the right format, ready to be served via Tinkerbell.

--- a/shell.nix
+++ b/shell.nix
@@ -42,6 +42,7 @@ mkShell {
   buildInputs = [
     git
     linuxkit
+    s3cmd
   ];
   shellHook =
     ''


### PR DESCRIPTION
This commit create a new `dist` make target that packages a `tar.gz`
with a compatible layout with the current OSIE.

In this way it can work as quick replacement in tinkerbell/sandbox.

It is a manual process at this stage but the tar.gz gets pushed to s3
and it can be downloaded via sandbox. Right now take this URL as "good
enough":

http://s.gianarb.it/noname/noname-master.tar.gz

When you run the `setup.sh` script in Sandbox it creates a set of
directories and it download OSIE `sandbox/deploy/state/webroot/misc/osie/current`.

    sandbox/deploy/state/webroot/misc/osie/current $ tree -L 1 | clip
    .
    ├── discover-metal-x86_64.tar.gz
    ├── discover-rc
    ├── discover.sh
    ├── grub
    ├── initramfs-2a2
    ├── initramfs-aarch64
    ├── initramfs-amp
    ├── initramfs-hua
    ├── initramfs-qcom
    ├── initramfs-tx2
    ├── initramfs-x86_64
    ├── modloop-2a2
    ├── modloop-aarch64
    ├── modloop-amp
    ├── modloop-hua
    ├── modloop-qcom
    ├── modloop-tx2
    ├── modloop-x86_64
    ├── osie-aarch64.tar.gz
    ├── osie-installer-rc
    ├── osie-installer.sh
    ├── osie-runner-x86_64.tar.gz
    ├── osie-x86_64.tar.gz
    ├── repo-aarch64 -> ../../../alpine/edge
    ├── repo-x86_64 -> ../../../alpine/v3.12
    ├── rescue-helper-rc
    ├── rescue-helper.sh
    ├── runner-rc
    ├── runner.sh
    ├── vmlinuz-2a2
    ├── vmlinuz-aarch64
    ├── vmlinuz-amp
    ├── vmlinuz-hua
    ├── vmlinuz-qcom
    ├── vmlinuz-tx2
    └── vmlinuz-x86_64

    1 directory, 35 files

This is the layout by default. If you want to replace OSIE with noname
you can move `current` to `nop` for example:

    mv ./deploy/state/webroot/misc/osie/current ./deploy/state/webroot/misc/osie/nop

You can download an unpack the new tar

    mkdir current
    wget http://s.gianarb.it/noname/noname-master.tar.gz
    tar xzvf -O ./current ./noname-master.tar.gz

And you are ready to go, now iPXE will boot noname instead of OSIE.

Sandbox has a file called
[current_versions.sh](https://github.com/tinkerbell/sandbox/blob/master/current_versions.sh).
If you change `OSIE_DOWNLOAD_LINK` with the noname link the setup.sh
script will download the OS again and it will uncompress it in
the right location (only if ./deploy/state/webroot/misc/osie/current does not exist)