### PR TITLE
nix: misc/nit fixes

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+has nix && use nix
+dotenv_if_exists # will allow env from .env file to override

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,1 @@
-out
-dist
-tinkie-*.tar.gz
-hook-*.tar.gz
-hook-ci.yaml
+.env

--- a/shell.nix
+++ b/shell.nix
@@ -45,12 +45,9 @@ let
 in
 mkShell {
   buildInputs = [
+    docker-ov
     git
     linuxkit
     s3cmd
-    docker-ov
   ];
-  shellHook =
-    ''
-    '';
 }

--- a/shell.nix
+++ b/shell.nix
@@ -17,37 +17,21 @@ let
     buildxSupport = true;
   };
 
-  linuxkit = buildGoPackage rec {
-    pname = "linuxkit";
-    version = "4cdf6bc56dd43227d5601218eaccf53479c765b9";
-
-    goPackagePath = "github.com/linuxkit/linuxkit";
-
+  linuxkit-ov = linuxkit.overrideAttrs (oldAttrs: rec {
+    version = "unstable-g${builtins.substring 0 9 src.rev}";
     src = fetchFromGitHub {
       owner = "linuxkit";
       repo = "linuxkit";
       rev = "4cdf6bc56dd43227d5601218eaccf53479c765b9";
       sha256 = "1w4ly0i8mx7p5a3y25ml6j4vxz42vdcacx0fbv23najcz7qh3810";
     };
-
-    subPackages = [ "src/cmd/linuxkit" ];
-
-    buildFlagsArray = [ "-ldflags=-s -w -X ${goPackagePath}/src/cmd/linuxkit/version.GitCommit=${src.rev} -X ${goPackagePath}/src/cmd/linuxkit/version.Version=${version}" ];
-
-    meta = with lib; {
-      description = "A toolkit for building secure, portable and lean operating systems for containers";
-      license = licenses.asl20;
-      homepage = "https://github.com/linuxkit/linuxkit";
-      maintainers = [ maintainers.nicknovitski ];
-      platforms = platforms.unix;
-    };
-  };
+  });
 in
 mkShell {
   buildInputs = [
     docker-ov
     git
-    linuxkit
+    linuxkit-ov
     s3cmd
   ];
 }


### PR DESCRIPTION
## Description

Mostly makes the shell.nix better by avoiding duplicating all of the linuxkit derivation in favor of overriding the linuxkit src bits.

## Why is this needed

Better to override only the minimal bits. Also adds direnv's .envrc file so matches other tinkerbell repos and brings much happiness.

## How Has This Been Tested?

Everything still works.

## How are existing users impacted? What migration steps/scripts do we need?

Save .01s when starting to develop here, each time!