### PR TITLE
mergify: Update PR rule condition to base=main

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,7 @@
 pull_request_rules:
   - name: Automatic merge on approval
     conditions:
-      - base=master
+      - base=main
       - "#approved-reviews-by>=1"
       - "#review-requested=0"
       - "#changes-requested-reviews-by=0"


### PR DESCRIPTION
## Description

Fixes the mergify config from the recent default branch rename from master -> main.

## Why is this needed

Sets us up for mergify to merge again.
