### PR TITLE
Fixes path to correct image

### DIFF
--- a/hook.yaml
+++ b/hook.yaml
@@ -1,5 +1,5 @@
 kernel:
-        image: quay.io/tinkerbell/hook-kernel:5.10.11
+  image: quay.io/tinkerbell/hook-kernel:5.10.11
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:v0.8

--- a/hook.yaml
+++ b/hook.yaml
@@ -1,5 +1,5 @@
 kernel:
-  image: thebsdbox/kernel:5.10.bpf
+        image: quay.io/tinkerbell/hook-kernel:5.10.11
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:v0.8


### PR DESCRIPTION
## Description

`hook.yaml` was referencing the wrong image name

## Why is this needed

Fixes path to the image on quay.io

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
