### PR TITLE
Bumped version of linuxkit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,11 +40,12 @@ jobs:
         push: true
         tags: localhost:5000/tinkerbell/hook-docker:0.0
 
-    - run: sed -e 's/quay.io/localhost:5000/g' hook.yaml > hook-ci.yaml
-
     - uses: cachix/install-nix-action@v13
       with:
         nix_path: nixpkgs=channel:nixos-unstable
+
+    # Replace hook-{bootkit,docker} but not hook-kernel
+    - run: sed -E -e 's,quay.io/tinkerbell/hook-(bootkit|docker),localhost:5000/tinkerbell/hook-\1,g' hook.yaml | tee hook-ci.yaml
 
     - run: ./hack/ci-build.sh
       env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 .env
+hook-*.tar.gz
+dist/
+out/
+tink-docker/local/
+bootkit/local/
+
+*.swp

--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,11 @@ export DOCKER_CLI_EXPERIMENTAL := enabled
 
 image-amd64:
 	mkdir -p out
-	linuxkit build -docker -disable-content-trust -pull -format kernel+initrd -name hook-x86_64 -dir out $(LINUXKIT_CONFIG)
+	linuxkit build -docker -pull -format kernel+initrd -name hook-x86_64 -dir out $(LINUXKIT_CONFIG)
 
 image-arm64:
 	mkdir -p out
-	linuxkit build -docker -disable-content-trust -pull -arch arm64 -format kernel+initrd -name hook-aarch64 -dir out $(LINUXKIT_CONFIG)
+	linuxkit build -docker -pull -arch arm64 -format kernel+initrd -name hook-aarch64 -dir out $(LINUXKIT_CONFIG)
 
 image: image-amd64 image-arm64
 
@@ -110,3 +110,8 @@ ifeq ($(shell git rev-parse --abbrev-ref HEAD),master)
 	s3cmd sync ./hook-${GIT_VERSION}.tar.gz s3://s.gianarb.it/hook/${GIT_VERSION}.tar.gz
 	s3cmd cp s3://s.gianarb.it/hook/hook-${GIT_VERSION}.tar.gz s3://s.gianarb.it/hook/hook-master.tar.gz
 endif
+
+.PHONY: clean
+clean:
+	rm ./hook-${GIT_VERSION}.tar.gz
+	rm -rf dist/ out/ tink-docker/local/ bootkit/local/

--- a/shell.nix
+++ b/shell.nix
@@ -22,8 +22,8 @@ let
     src = fetchFromGitHub {
       owner = "linuxkit";
       repo = "linuxkit";
-      rev = "4cdf6bc56dd43227d5601218eaccf53479c765b9";
-      sha256 = "1w4ly0i8mx7p5a3y25ml6j4vxz42vdcacx0fbv23najcz7qh3810";
+      rev = "ccece6a4889e15850dfbaf6d5170939c83edb103";
+      sha256 = "1hx5k0l9gniz9aj9li8dkiniqs77pyfcl979y75yqm3mynrdz9ca";
     };
   });
 in


### PR DESCRIPTION
## Description

Linuxkit has removed the `-disable-content-trust` flag

* removed deprecated linuxkit flag from Makefile
* Added clean Make target
* Added build dirs to gitignore
* Fixed broken CI from #48

## Why is this needed

I couldn't get the previously used version of linuxkit to build.

## How Has This Been Tested?
I built a hook image locally and booted a Tink worker with the latest version of linuxkit

## How are existing users impacted? What migration steps/scripts do we need?

Users can use and build a with a newer version of linuxkit


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required): N/A
- [x] added unit or e2e tests: N/A
- [x] provided instructions on how to upgrade: N/A
