### PR TITLE
Add 'make lint' rule to run golangci-lint, shellcheck, hadolint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,193 @@
+# NOTE: This file is populated by the lint-install tool. Local adjustments may be overwritten.
+linters-settings:
+  cyclop:
+    # NOTE: This is a very high transitional threshold
+    max-complexity: 37
+    package-average: 34.0
+    skip-tests: true
+
+  gocognit:
+    # NOTE: This is a very high transitional threshold
+    min-complexity: 98
+
+  dupl:
+    threshold: 200
+
+  goconst:
+    min-len: 4
+    min-occurrences: 5
+    ignore-tests: true
+
+  errorlint:
+    # these are still common in Go: for instance, exit errors.
+    asserts: false
+
+  exhaustive:
+    default-signifies-exhaustive: true
+
+  nestif:
+    min-complexity: 8
+
+  nolintlint:
+      require-explanation: true
+      allow-unused: false
+      require-specific: true
+
+  revive:
+    ignore-generated-header: true
+    severity: warning
+    rules:
+      - name: atomic
+      - name: blank-imports
+      - name: bool-literal-in-expr
+      - name: confusing-naming
+      - name: constant-logical-expr
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: deep-exit
+      - name: defer
+      - name: range-val-in-closure
+      - name: range-val-address
+      - name: dot-imports
+      - name: empty-block
+      - name: error-naming
+      - name: error-return
+      - name: error-strings
+      - name: errorf
+      - name: exported
+      - name: identical-branches
+      - name: if-return
+      - name: import-shadowing
+      - name: increment-decrement
+      - name: indent-error-flow
+      - name: indent-error-flow
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: redefines-builtin-id
+      - name: superfluous-else
+      - name: struct-tag
+      - name: time-naming
+      - name: unexported-naming
+      - name: unexported-return
+      - name: unnecessary-stmt
+      - name: unreachable-code
+      - name: unused-parameter
+      - name: var-declaration
+      - name: var-naming
+      - name: unconditional-recursion
+      - name: waitgroup-by-value
+
+  staticcheck:
+    go: "1.16"
+
+  unused:
+    go: "1.16"
+
+output:
+  sort-results: true
+
+linters:
+  disable-all: true
+  enable:
+    - asciicheck
+    - bodyclose
+    - cyclop
+    - deadcode
+    - dogsled
+    - dupl
+    - durationcheck
+    - errcheck
+    # errname is only available in golangci-lint v1.42.0+ - wait until v1.43 is available to settle
+    #- errname
+    - errorlint
+    - exhaustive
+    - exportloopref
+    - forcetypeassert
+    - gocognit
+    - goconst
+    - gocritic
+    - godot
+    - gofmt
+    - goheader
+    - goimports
+    - goprintffuncname
+    - gosimple
+    - govet
+    - ifshort
+    - importas
+    - ineffassign
+    - makezero
+    - misspell
+    - nakedret
+    - nestif
+    - nilerr
+    - noctx
+    - nolintlint
+    - predeclared
+    - promlinter
+    - revive
+    - rowserrcheck
+    - sqlclosecheck
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - thelper
+    - tparallel
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - wastedassign
+    - whitespace
+
+  # Disabled linters, due to being misaligned with Go practices
+  # - exhaustivestruct
+  # - gochecknoglobals
+  # - gochecknoinits
+  # - goconst
+  # - godox
+  # - goerr113
+  # - gomnd
+  # - lll
+  # - nlreturn
+  # - testpackage
+  # - wsl
+
+  # Disabled linters, due to not being relevant to our code base:
+  # - maligned
+  # - prealloc "For most programs usage of prealloc will be a premature optimization."
+
+  # Disabled linters due to bad error messages or bugs
+  # - gofumpt
+  # - gosec
+  # - tagliatelle
+
+
+issues:
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - gocyclo
+        - errcheck
+        - dupl
+        - gosec
+
+    - path: cmd.*
+      linters:
+        - noctx
+
+    - path: main\.go
+      linters:
+        - noctx
+
+    # This check is of questionable value
+    - linters:
+        - tparallel
+      text: "call t.Parallel on the top level as well as its subtests"
+
+  # Don't hide lint issues just because there are many of them
+  max-same-issues: 0
+  max-issues-per-linter: 0

--- a/Makefile
+++ b/Makefile
@@ -115,3 +115,34 @@ endif
 clean:
 	rm ./hook-${GIT_VERSION}.tar.gz
 	rm -rf dist/ out/ tink-docker/local/ bootkit/local/
+
+# BEGIN: lint-install ../hook
+
+GOLINT_VERSION ?= v1.42.0
+HADOLINT_VERSION ?= v2.6.1
+SHELLCHECK_VERSION ?= v0.7.2
+LINT_OS := $(shell uname)
+LINT_LOWER_OS  = $(shell echo $OS | tr '[:upper:]' '[:lower:]')
+LINT_ARCH := $(shell uname -m)
+GOLINT_CONFIG:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))/.golangci.yml
+
+lint: out/linters/shellcheck-$(SHELLCHECK_VERSION)/shellcheck out/linters/hadolint-$(HADOLINT_VERSION) out/linters/golangci-lint-$(GOLINT_VERSION)
+	find . -name go.mod | xargs -n1 dirname | xargs -n1 -I{} sh -c "cd {} && golangci-lint run -c $(GOLINT_CONFIG)"
+	out/linters/shellcheck-$(SHELLCHECK_VERSION)/shellcheck $(shell find . -name "*.sh")
+	out/linters/hadolint-$(HADOLINT_VERSION) $(shell find . -name "*Dockerfile")
+
+out/linters/shellcheck-$(SHELLCHECK_VERSION)/shellcheck:
+	mkdir -p out/linters
+	curl -sfL https://github.com/koalaman/shellcheck/releases/download/v0.7.2/shellcheck-$(SHELLCHECK_VERSION).$(LINT_OS).$(LINT_ARCH).tar.xz | tar -C out/linters -xJf -
+
+out/linters/hadolint-$(HADOLINT_VERSION):
+	mkdir -p out/linters
+	curl -sfL https://github.com/hadolint/hadolint/releases/download/v2.6.1/hadolint-$(LINT_OS)-$(LINT_ARCH) > out/linters/hadolint-$(HADOLINT_VERSION)
+	chmod u+x out/linters/hadolint-$(HADOLINT_VERSION)
+
+out/linters/golangci-lint-$(GOLINT_VERSION):
+	mkdir -p out/linters
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b out/linters $(GOLINT_VERSION)
+	mv out/linters/golangci-lint out/linters/golangci-lint-$(GOLINT_VERSION)
+
+# END: lint-install ../hook


### PR DESCRIPTION
NOTE: This is using an experimental branch of https://github.com/tinkerbell/lint-install that works on projects with multiple Go modules.