### PR TITLE
Adds an alias to make debugging easier!

### DIFF
--- a/hook.yaml
+++ b/hook.yaml
@@ -74,6 +74,13 @@ services:
 files:
   - path: etc/docker/daemon.json
     contents: '{"debug": true}'
+  - path: etc/profile.d/local.sh
+    contents: |
+      alias l='ls -lF'
+      alias ll='l -a'
+      alias ctr='ctr -n services.linuxkit'
+      alias docker='ctr tasks exec --tty --exec-id shell docker docker'
+    mode: "0644"
 trust:
   org:
     - linuxkit

--- a/hook.yaml
+++ b/hook.yaml
@@ -76,10 +76,7 @@ files:
     contents: '{"debug": true}'
   - path: etc/profile.d/local.sh
     contents: |
-      alias l='ls -lF'
-      alias ll='l -a'
-      alias ctr='ctr -n services.linuxkit'
-      alias docker='ctr tasks exec --tty --exec-id shell docker docker'
+      alias docker='ctr -n services.linuxkit tasks exec --tty --exec-id shell docker docker'
     mode: "0644"
 trust:
   org:

--- a/hook_debug.yaml
+++ b/hook_debug.yaml
@@ -11,6 +11,9 @@ onboot:
     image: linuxkit/sysctl:v0.8
   - name: sysfs
     image: linuxkit/sysfs:v0.8
+  - name: dhcpcd
+    image: linuxkit/dhcpcd:v0.8
+    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
     image: linuxkit/getty:v0.8
@@ -67,6 +70,13 @@ files:
     source: ~/.ssh/id_rsa.pub
     mode: "0600"
     optional: true
+  - path: etc/profile.d/local.sh
+    contents: |
+      alias l='ls -lF'
+      alias ll='l -a'
+      alias ctr='ctr -n services.linuxkit'
+      alias docker='ctr tasks exec --tty --exec-id shell docker docker'
+    mode: "0644"
 trust:
   org:
     - linuxkit

--- a/hook_debug.yaml
+++ b/hook_debug.yaml
@@ -11,9 +11,6 @@ onboot:
     image: linuxkit/sysctl:v0.8
   - name: sysfs
     image: linuxkit/sysfs:v0.8
-  - name: dhcpcd
-    image: linuxkit/dhcpcd:v0.8
-    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
     image: linuxkit/getty:v0.8

--- a/hook_debug.yaml
+++ b/hook_debug.yaml
@@ -72,10 +72,7 @@ files:
     optional: true
   - path: etc/profile.d/local.sh
     contents: |
-      alias l='ls -lF'
-      alias ll='l -a'
-      alias ctr='ctr -n services.linuxkit'
-      alias docker='ctr tasks exec --tty --exec-id shell docker docker'
+      alias docker='ctr -n services.linuxkit tasks exec --tty --exec-id shell docker docker'
     mode: "0644"
 trust:
   org:


### PR DESCRIPTION
## Description

This adds an `alias` to hook.yaml and hook_debug.yaml, that makes debugging much more simple.
 
## Why is this needed

Remembering the `ctr` command is nigh on impossible. 


Fixes: #

The pain of trying to remember the `ctr` flags :-)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
