### PR TITLE
Add a oneshot DHCP call when hook starts

### DIFF
--- a/hook_debug.yaml
+++ b/hook_debug.yaml
@@ -11,6 +11,9 @@ onboot:
     image: linuxkit/sysctl:v0.8
   - name: sysfs
     image: linuxkit/sysfs:v0.8
+  - name: dhcpcd
+    image: linuxkit/dhcpcd:v0.8
+    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
 services:
   - name: getty
     image: linuxkit/getty:v0.8


### PR DESCRIPTION
## Description

Adds a oneshot DHCP call when hook starts

## Why is this needed

This ensures that networking configuration exists BEFORE services start.
<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
