### PR TITLE
Don't try to login to quay if a push is made by dependabot

### DIFF
--- a/.github/workflows/kernel-push.yaml
+++ b/.github/workflows/kernel-push.yaml
@@ -12,6 +12,7 @@ jobs:
       uses: actions/checkout@v2.3.5
 
     - name: Login to quay.io
+      if: ${{ github.actor != 'dependabot[bot]' }}
       uses: docker/login-action@v1
       with:
         registry: quay.io

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -18,6 +18,7 @@ jobs:
       uses: docker/setup-buildx-action@v1.3.0
 
     - name: Login to quay.io
+      if: ${{ github.actor != 'dependabot[bot]' }}
       uses: docker/login-action@v1
       with:
         registry: quay.io


### PR DESCRIPTION
## Description

Avoids logging into quay for dependabot builds.

## Why is this needed

Fixes #92

Dependabot PRs are different than other non-contributor PRs in that the branch comes from this repo, which normally allows the secret to be available for CI yet the builds still fail (see [1], [2]). It seems that GitHub does not make secrets available for these PRs as yet another special case [3]. If we skip logging in to quay for dependabot then we side step this all together.

Dependabot pushes/PRs can be recognized by the github.actor value according to the GitHub docs [3].

[1]: https://github.com/tinkerbell/hook/pull/89
[2]: https://github.com/tinkerbell/hook/pull/95
[3]: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions#handling-pull_request-events

I wanted to avoid logging in for non main pushes all together but that may make kernel testing harder than strictly necessary.

## How Has This Been Tested?

CI?

## How are existing users impacted? What migration steps/scripts do we need?

Updated dependencies sooner hopefully.
