### PR TITLE
ci: Only push to quay if github.actor is not dependabot

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -30,7 +30,7 @@ jobs:
       with:
         context: ./bootkit/
         platforms: linux/amd64,linux/arm64
-        push: true
+        push: ${{ github.actor != 'dependabot[bot]' }}
         tags: quay.io/tinkerbell/hook-bootkit:0.0
 
     - name: Build and push tink-docker
@@ -38,7 +38,7 @@ jobs:
       with:
         context: ./tink-docker/
         platforms: linux/amd64,linux/arm64
-        push: true
+        push: ${{ github.actor != 'dependabot[bot]' }}
         tags: quay.io/tinkerbell/hook-docker:0.0
 
     - uses: cachix/install-nix-action@v16


### PR DESCRIPTION
## Description

Avoids pushing to quay if the PR/push originates from dependabot.

## Why is this needed

We skipped logging in to quay.io when github.actor is dependabot in [#96] but
did not check if any pushes were attempted. This change will avoid that
failure.

This was missed in the subsequent dependabot PRs [#89] and [#95] because there
was no branch protection setup and I added the ready-to-merge label so mergify
merged it :(. I've added branch protection to require the actions to pass.

[#89]: https://github.com/tinkerbell/hook/pull/89
[#95]: https://github.com/tinkerbell/hook/pull/95
[#96]: https://github.com/tinkerbell/hook/pull/96

## How Has This Been Tested?

CI
