### PR TITLE
Update hook kernel to 5.10.85

### DIFF
--- a/hook.yaml
+++ b/hook.yaml
@@ -1,6 +1,5 @@
 kernel:
- #  image: quay.io/tinkerbell/hook-kernel:5.10.85
-  image: docker.io/sublyme/hook-kernel:5.10.85-testing
+  image: quay.io/tinkerbell/hook-kernel:5.10.85
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:v0.8

--- a/hook.yaml
+++ b/hook.yaml
@@ -1,5 +1,6 @@
 kernel:
-  image: quay.io/tinkerbell/hook-kernel:5.10.57
+ #  image: quay.io/tinkerbell/hook-kernel:5.10.85
+  image: docker.io/sublyme/hook-kernel:5.10.85-testing
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 init:
   - linuxkit/init:v0.8

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -242,11 +242,11 @@ endef
 # Debug targets only for latest stable and LTS stable
 #
 ifeq ($(ARCH),x86_64)
-$(eval $(call kernel,5.10.57,5.10.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,5.10.85,5.10.x,$(EXTRA),$(DEBUG)))
 #$(eval $(call kernel,5.4.28,5.4.x,-rt,))
 
 else ifeq ($(ARCH),aarch64)
-$(eval $(call kernel,5.10.57,5.10.x,$(EXTRA),$(DEBUG)))
+$(eval $(call kernel,5.10.85,5.10.x,$(EXTRA),$(DEBUG)))
 #$(eval $(call kernel,5.4.28,5.4.x,-rt,))
 
 endif

--- a/kernel/config-5.10.x-aarch64
+++ b/kernel/config-5.10.x-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.10.57 Kernel Configuration
+# Linux/arm64 5.10.85 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (Alpine 9.2.0) 9.2.0"
 CONFIG_CC_IS_GCC=y
@@ -4780,6 +4780,7 @@ CONFIG_STAGING_BOARD=y
 # CONFIG_LTE_GDM724X is not set
 # CONFIG_GS_FPGABOOT is not set
 # CONFIG_UNISYSSPAR is not set
+# CONFIG_COMMON_CLK_XLNX_CLKWZRD is not set
 # CONFIG_FB_TFT is not set
 # CONFIG_KS7010 is not set
 # CONFIG_BCM_VIDEOCORE is not set

--- a/kernel/config-5.10.x-x86_64
+++ b/kernel/config-5.10.x-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 5.10.57 Kernel Configuration
+# Linux/x86 5.10.85 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="gcc (Alpine 9.2.0) 9.2.0"
 CONFIG_CC_IS_GCC=y


### PR DESCRIPTION
## Description

This PR updates the hook kernel to 5.10.85 and could maybe close #90. Earlier 5.10.x kernel versions, such as 5.10.57 which was the previously released kernel for hook, seemed to have a bug in the `igc` module that prevented certain NICs from functioning. Later kernel versions fixed this issue.

We need to discuss longer term plans for supporting hook though. Hook had not seen a kernel update for many months, but meanwhile new hardware requiring support continues to come onto the market. We should formulate a plan for moving hook to the next LTS kernel which is 5.15 and also a release cadence as new kernels release upstream.

## Why is this needed

Fixes: #90

## How Has This Been Tested?

**Note:** this still needs to be run through the standard tinkerbell CI tests.

This has been tested with a single device ([Minisforum HX90](https://store.minisforum.com/products/hx90?variant=40508846440609)) as detailed in the initial issue. More thorough testing with a larger variety of hardware devices might be desirable.

After making the detailed changes, Hook and the kernel were built outside of CI on my development desktop. A test instance of the tinkerbell sandbox was setup using [ansible and podman](https://github.com/epiphyte-org/sandbox/tree/ansible-podman_container) on the same workstation. After the example sandbox workflow was modified slightly to account for the presence of an nvme SSD in the HX90, the device was powered on and successfully imaged via hook and the example sandbox workflow. This resulted in the HX90 having a bootable Ubuntu Focal image installed.

## How are existing users impacted? What migration steps/scripts do we need?

Users should only need to download and deploy the updated pre-built binaries for hook if they desire to upgrade. This upgrade is really not "mandatory" as prior versions of hook should continue to function _just fine_. Many users may opt to not upgrade unless they are encountering compatibility issues with the prior release of hook. The remaining work that needs to happen is on the project side to get these changes built and published for public consumption.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
