### PR TITLE
Send container logs to syslog server

### DIFF
--- a/hook.yaml
+++ b/hook.yaml
@@ -53,7 +53,6 @@ services:
     binds:
      - /etc/resolv.conf:/etc/resolv.conf
      - /lib/modules:/lib/modules
-     - /etc/docker/daemon.json:/etc/docker/daemon.json
      - /var/run/docker:/var/run
      - /var/run/worker:/worker
      - /dev/console:/dev/console
@@ -78,8 +77,6 @@ services:
       mkdir:
         - /var/run/docker
 files:
-  - path: etc/docker/daemon.json
-    contents: '{"debug": true}'
   - path: etc/profile.d/local.sh
     contents: |
       alias docker='ctr -n services.linuxkit tasks exec --tty --exec-id cmd docker docker'

--- a/hook.yaml
+++ b/hook.yaml
@@ -23,6 +23,8 @@ onboot:
 services:
   - name: getty
     image: linuxkit/getty:v0.8
+    binds.add:
+     - /etc/profile.d/local.sh:/etc/profile.d/local.sh
     env:
      - INSECURE=true
   - name: rngd
@@ -80,7 +82,8 @@ files:
     contents: '{"debug": true}'
   - path: etc/profile.d/local.sh
     contents: |
-      alias docker='ctr -n services.linuxkit tasks exec --tty --exec-id shell docker docker'
+      alias docker='ctr -n services.linuxkit tasks exec --tty --exec-id cmd docker docker'
+      alias docker-shell='ctr -n services.linuxkit tasks exec --tty --exec-id shell docker sh'
     mode: "0644"
 trust:
   org:

--- a/tink-docker/Dockerfile
+++ b/tink-docker/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:experimental
 
-FROM golang:1.15-alpine as dev
+FROM golang:1.18-alpine as dev
 COPY . /src/
 WORKDIR /src
 ENV GO111MODULE=on
@@ -8,7 +8,7 @@ RUN --mount=type=cache,sharing=locked,id=gomod,target=/go/pkg/mod/cache \
     --mount=type=cache,sharing=locked,id=goroot,target=/root/.cache/go-build \
     CGO_ENABLED=0 go build -a -ldflags '-w -extldflags "-static"' -o /tink-docker
 
-FROM docker:19.03.8-dind
+FROM docker:20.10.14-dind
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
 RUN apk update; apk add kexec-tools
 COPY --from=dev /tink-docker .

--- a/tink-docker/go.mod
+++ b/tink-docker/go.mod
@@ -1,3 +1,3 @@
 module github.com/tinkerbell/hook/tink-docker
 
-go 1.15
+go 1.18

--- a/tink-docker/main_test.go
+++ b/tink-docker/main_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestWriteToDisk(t *testing.T) {
+	tests := map[string]struct {
+		cfg     dockerConfig
+		want    []byte
+		wantErr error
+	}{
+		"success":                {cfg: dockerConfig{Debug: false, LogDriver: "json-file"}, want: []byte(`{"debug":false,"log-driver":"json-file"}`)},
+		"success - empty struct": {cfg: dockerConfig{}, want: []byte(`{"debug":false}`)},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Create a temporary directory
+			dir, err := ioutil.TempDir("", "tink-docker")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(dir)
+			loc := dir + "daemon.json"
+
+			err = tt.cfg.writeToDisk(loc)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("got err %v, want %v", err, tt.wantErr)
+			}
+
+			if tt.wantErr == nil {
+				got, err := ioutil.ReadFile(loc)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if !bytes.Equal(got, tt.want) {
+					t.Fatalf("\ngot:\n %s\nwant:\n %s", got, tt.want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Currently, the only way to see container logs for workflows is to access the console of a machine. This makes troubleshooting difficult. This PR sends the tink-worker and workflow container logs back to aSyslog host.

## Why is this needed

Fixes: #81 
Fixes: #86 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
