### PR TITLE
Fixes for #130 which was fixes for #105

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,9 +56,6 @@ jobs:
           # Build and push the container images
           nix-shell --run 'make TAG=${{steps.commitid.outputs.short}} push'
           nix-shell --run 'make TAG=latest push'
-          # Build and push the linuxkit images
-          nix-shell --run 'make TAG=${{steps.commitid.outputs.short}} deploy'
-          nix-shell --run 'make TAG=latest deploy'
 
       - uses: actions/upload-artifact@v3
         with:

--- a/hook.yaml
+++ b/hook.yaml
@@ -60,7 +60,6 @@ services:
       - type: cgroup
         options: ["rw", "nosuid", "noexec", "nodev", "relatime"]
     binds:
-      #dbg- /etc/docker/daemon.json:/etc/docker/daemon.json
       - /dev/console:/dev/console
       - /dev:/dev
       - /etc/resolv.conf:/etc/resolv.conf


### PR DESCRIPTION
## Description

- Makes CI green again by avoiding attempting to push the linuxkit images via `make deploy` which was deleted.
- Removes the dbg only binding of /etc/daemon.json which breaks hook-docker since it ends up being mounted read-only.

## Why is this needed

Fixes CI and dbg runs.

## How Has This Been Tested?

CI fix should just work.

I've been running with the daemon.json drop in a different branch and thought it was in branch for #130. 

## How are existing users impacted? What migration steps/scripts do we need?

CI is :heavy_check_mark: not :x: which makes us all feel warm and fuzzy.

dbg builds are actually useful and work.