### PR TITLE
Rework use of actions/upload-artifact

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,5 +59,5 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: hook-${{steps.commitid.outputs.short}}.tar.gz
-          path: out/${{steps.commitid.outputs.short}}/rel/hook-${{steps.commitid.outputs.short}}.tar.gz
+          name: hook-${{steps.commitid.outputs.short}}
+          path: out/${{steps.commitid.outputs.short}}/rel/hook_*.tar.gz


### PR DESCRIPTION
## Description

Uses the correct path to the build files when passing them to upload-artifact so that the files are actually uploaded. 

## Why is this needed

Files weren't being uploaded.

## How Has This Been Tested?

From my fork.

## How are existing users impacted? What migration steps/scripts do we need?

They can fetch files built by official CI instead of being required to build locally.