### PR TITLE
ci: Limit the kernel push only to branch pushes

### DIFF
--- a/.github/workflows/kernel-push.yaml
+++ b/.github/workflows/kernel-push.yaml
@@ -4,6 +4,8 @@ on:
     paths:
       - kernel/**
       - "!kernel/README.md"
+    branches:
+      - "**"
 jobs:
   kernel-publish:
     runs-on: self-hosted


### PR DESCRIPTION
## Description

Avoids building the kernel for tag pushes.

## Why is this needed

The kernel builds are currently filtering the events that cause the build depending on the path of files changed. The path filter is not evaluated for tag pushes though. This causes the kernel to be re-pushed on tags which is unexpected and confusing. I'd rather avoid confusion in the kernel build/push process if possible.