### PR TITLE
Use a multiarch manifest kernel

### DIFF
--- a/hook.yaml
+++ b/hook.yaml
@@ -1,5 +1,5 @@
 kernel:
-  image: quay.io/tinkerbell/hook-kernel:5.10.85
+  image: quay.io/tinkerbell/hook-kernel:5.10.85-5604bb0dc1cdb6263770a82bf91cbf7e00ffdd5c
   cmdline: "console=tty0 console=ttyS0 console=ttyAMA0 console=ttysclp0"
 
 init:


### PR DESCRIPTION
## Description

Changes the kernel referenced in hook.yaml to one that is actually a multiarch manifest.

## Why is this needed

The previous kernel being used had only had the amd64 flavor available on
quay. Linuxkit has no sanity check to ensure the fetched image platform
matches the one specified in the command line args. Thus the recent builds
of hook all have an x86_64 kernel for both amd64 and arm64 images.

## How Has This Been Tested?

Ran `make dist` and `file` on the kernel files:


## How are existing users impacted? What migration steps/scripts do we need?

Hook arm64 builds have the correct kernel for the arch and thus should boot.