### PR TITLE
Create VLAN interface before DHCPing:

### DIFF
--- a/files/dhcp.sh
+++ b/files/dhcp.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+# This script will run the dhcp client. If `vlan_id=` in `/proc/cmdline` has a value, it will run the dhcp client only on the
+# VLAN interface.
+# This script accepts an input parameter of true or false.
+# true: run the dhcp client with the one shot option
+# false: run the dhcp client as a service
+set -x
+
+run_dhcp_client() {
+	one_shot="$1"
+	al="eth*"
+
+	# shellcheck disable=SC2013
+	for x in $(cat /proc/cmdline); do
+		# shellcheck disable=SC2022
+		echo "$x" | grep -qe 'vlan_id*' || continue
+		vlan_id="${x#vlan_id=}"
+		if [ -n "$vlan_id" ]; then
+			al="eth*.*"
+		fi
+	done
+
+	# Boots send kernel command line parameter "ip=dhcp", this causes the system to configure the network interface(s) with DHCP.
+	# When an environment's network configuration has this machine connected a trunked interface with a default/native VLAN, the
+	# interface will be configured on the default/native VLAN because we haven't yet configured the VLAN interface. Boots will respond
+	# to this DHCP request because in this scenario it is not VLAN aware. Also in this scenario, the machine will end up being configured
+	# with 2 default routes. To resolve this, we remove the default route and IP that kernel added and let the dhcpcd handle setting the route.
+	ip route del default || true
+	ipa=$(ip -4 -o addr show dev eth0 | awk '{print $4}')
+	ip addr del dev eth0 "$ipa" || true
+
+	if [ "$one_shot" = "true" ]; then
+		/sbin/dhcpcd --nobackground -f /dhcpcd.conf --allowinterfaces "${al}" -1
+	else
+		/sbin/dhcpcd --nobackground -f /dhcpcd.conf --allowinterfaces "${al}"
+	fi
+
+}
+
+# we always return true so that a failure here doesn't block the next container service from starting. Ideally, we always
+# want the getty service to start so we can debug failures.
+run_dhcp_client "$1" || true

--- a/files/dhcpcd.conf
+++ b/files/dhcpcd.conf
@@ -1,0 +1,15 @@
+# Default values for dhcpcd from linuxkit/dhcpcd:v0.8 with `allowinterfaces eth*` removed
+# This allows the `--allowinterfaces` flag of dhcpcd to specify the allowinterfaces.
+hostname
+clientid
+persistent
+option rapid_commit
+option domain_name_servers, domain_name, domain_search, host_name
+option classless_static_routes
+option ntp_servers
+option interface_mtu
+require dhcp_server_identifier
+slaac private
+nodelay
+noarp
+waitip 4

--- a/files/vlan.sh
+++ b/files/vlan.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# This script will set up VLAN interfaces if `vlan_id=` in `/proc/cmdline` has a value
+set -x
+
+add_vlan_interface() {
+	# shellcheck disable=SC2013
+	for param in $(cat /proc/cmdline); do
+		# shellcheck disable=SC2022
+		echo "$param" | grep -qe 'vlan_id*' || continue
+		vlan_id="${param#vlan_id=}"
+		if [ -n "$vlan_id" ]; then
+			for ifname in $(ip -4 -o link show | awk -F': ' '{print $2}'); do
+				[ "$ifname" = "lo" ] && continue
+				[ "$ifname" = "docker0" ] && continue
+				ip link add link "$ifname" name "$ifname.$vlan_id" type vlan id "$vlan_id"
+				ip link set "$ifname.$vlan_id" up
+			done
+			return
+		fi
+	done
+}
+
+# we always return true so that a failure here doesn't block the next container service from starting. Ideally, we always
+# want the getty service to start so we can debug failures.
+add_vlan_interface || true

--- a/hook.yaml
+++ b/hook.yaml
@@ -15,6 +15,12 @@ onboot:
   - name: sysfs
     image: linuxkit/sysfs:v0.8
 
+  - name: vlan
+    image: linuxkit/ip:6cc44dd4e18ddb02de01bc4b34b5799971b6a7bf
+    binds.add:
+      - /etc/ip/vlan.sh:/etc/ip/vlan.sh
+    command: ["/etc/ip/vlan.sh"]
+
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.8
     command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
@@ -96,6 +102,27 @@ files:
       alias       docker='ctr -n services.linuxkit tasks exec --tty --exec-id cmd hook-docker docker'
       alias docker-shell='ctr -n services.linuxkit tasks exec --tty --exec-id shell hook-docker sh'
     mode: "0644"
+
+  - path: etc/ip/vlan.sh
+    contents: |
+      #!/bin/sh
+      # This script will set up VLAN interfaces if `vlan_id=` in `/proc/cmdline` has a value
+      set -x
+
+      for x in $(cat /proc/cmdline); do
+        echo "$x" | grep -qe 'vlan_id*' || continue
+        vlan_id="${x#vlan_id=}"
+        if [ ! -z "$vlan_id" ]; then
+          for x in $(ip -4 -o link show | awk -F': ' '{print $2}'); do
+            [ "$x" == "lo" ] && continue
+            [ "$x" == "docker0" ] && continue
+            ip link add link "$x" name "$x.$vlan_id" type vlan id "$vlan_id"
+            ip link set "$x.$vlan_id" up
+          done
+          exit 0
+        fi
+      done
+    mode: "0777"
 
 #dbg  - path: root/.ssh/authorized_keys
 #dbg    source: ~/.ssh/id_rsa.pub

--- a/hook.yaml
+++ b/hook.yaml
@@ -23,10 +23,12 @@ onboot:
 
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.8
-    command: ["/sbin/dhcpcd", "--nobackground", "-f", "/dhcpcd.conf", "-1"]
+    command: ["/etc/ip/dhcp.sh", "true"]
     binds.add:
       - /var/lib/dhcpcd:/var/lib/dhcpcd
       - /run:/run
+      - /etc/ip/dhcp.sh:/etc/ip/dhcp.sh
+      - /dhcpcd.conf:/dhcpcd.conf
     runtime:
       mkdir:
         - /var/lib/dhcpcd
@@ -44,9 +46,12 @@ services:
 
   - name: dhcpcd
     image: linuxkit/dhcpcd:v0.8
+    command: ["/etc/ip/dhcp.sh", "false"]
     binds.add:
       - /var/lib/dhcpcd:/var/lib/dhcpcd
       - /run:/run
+      - /etc/ip/dhcp.sh:/etc/ip/dhcp.sh
+      - /dhcpcd.conf:/dhcpcd.conf
     runtime:
       mkdir:
         - /var/lib/dhcpcd
@@ -104,25 +109,16 @@ files:
     mode: "0644"
 
   - path: etc/ip/vlan.sh
-    contents: |
-      #!/bin/sh
-      # This script will set up VLAN interfaces if `vlan_id=` in `/proc/cmdline` has a value
-      set -x
-
-      for x in $(cat /proc/cmdline); do
-        echo "$x" | grep -qe 'vlan_id*' || continue
-        vlan_id="${x#vlan_id=}"
-        if [ ! -z "$vlan_id" ]; then
-          for x in $(ip -4 -o link show | awk -F': ' '{print $2}'); do
-            [ "$x" == "lo" ] && continue
-            [ "$x" == "docker0" ] && continue
-            ip link add link "$x" name "$x.$vlan_id" type vlan id "$vlan_id"
-            ip link set "$x.$vlan_id" up
-          done
-          exit 0
-        fi
-      done
+    source: "files/vlan.sh"
     mode: "0777"
+
+  - path: etc/ip/dhcp.sh
+    source: "files/dhcp.sh"
+    mode: "0777"
+
+  - path: dhcpcd.conf
+    source: "files/dhcpcd.conf"
+    mode: "0644"
 
 #dbg  - path: root/.ssh/authorized_keys
 #dbg    source: ~/.ssh/id_rsa.pub


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This enables creating VLAN interfaces based on the `vlan_id=` value in `/proc/cmdline`. No VLAN interface will be created if `vlan_id=` does not have a value.

## Why is this needed
This enables trunk vlan support across the Tink stack. https://github.com/tinkerbell/proposals/blob/main/proposals/0030/README.md

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
