### PR TITLE
Remove unused metadata network call

### DIFF
--- a/hook-bootkit/main.go
+++ b/hook-bootkit/main.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net/http"
 	"os"
 	"path"
 	"strings"
@@ -37,9 +36,6 @@ type tinkConfig struct {
 	workerID string
 	ID       string
 
-	// Metadata ID ... plus the other IDs :shrug:
-	MetadataID string `json:"id"`
-
 	// tinkWorkerImage is the Tink worker image location.
 	tinkWorkerImage string
 
@@ -62,12 +58,6 @@ func main() {
 
 	cmdLines := strings.Split(string(content), " ")
 	cfg := parseCmdLine(cmdLines)
-
-	// Get the ID from the metadata service
-	err = cfg.metaDataQuery()
-	if err != nil {
-		panic(err)
-	}
 
 	// Generate the path to the tink-worker
 	var imageName string
@@ -94,7 +84,6 @@ func main() {
 			fmt.Sprintf("TINKERBELL_TLS=%s", cfg.tinkServerTLS),
 			fmt.Sprintf("WORKER_ID=%s", cfg.workerID),
 			fmt.Sprintf("ID=%s", cfg.workerID),
-			fmt.Sprintf("container_uuid=%s", cfg.MetadataID),
 		},
 		AttachStdout: true,
 		AttachStderr: true,
@@ -219,44 +208,4 @@ func parseCmdLine(cmdLines []string) (cfg tinkConfig) {
 		}
 	}
 	return cfg
-}
-
-// metaDataQuery will query the metadata.
-func (cfg *tinkConfig) metaDataQuery() error {
-	spaceClient := http.Client{
-		Timeout: time.Second * 60, // Timeout after 60 seconds (seems massively long is this dial-up?)
-	}
-
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s:50061/metadata", cfg.tinkerbell), nil)
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("User-Agent", "bootkit")
-
-	res, getErr := spaceClient.Do(req)
-	if getErr != nil {
-		return err
-	}
-
-	if res.Body != nil {
-		defer res.Body.Close()
-	}
-
-	body, readErr := ioutil.ReadAll(res.Body)
-	if readErr != nil {
-		return err
-	}
-
-	var metadata struct {
-		ID string `json:"id"`
-	}
-
-	jsonErr := json.Unmarshal(body, &metadata)
-	if jsonErr != nil {
-		return err
-	}
-
-	cfg.MetadataID = metadata.ID
-	return err
 }

--- a/hook-bootkit/main.go
+++ b/hook-bootkit/main.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -51,7 +50,7 @@ func main() {
 	// // Read entire file content, giving us little control but
 	// // making it very simple. No need to close the file.
 
-	content, err := ioutil.ReadFile("/proc/cmdline")
+	content, err := os.ReadFile("/proc/cmdline")
 	if err != nil {
 		panic(err)
 	}

--- a/hook-docker/main.go
+++ b/hook-docker/main.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -32,7 +31,7 @@ func main() {
 	go rebootWatch()
 
 	// Parse the cmdline in order to find the urls for the repository and path to the cert
-	content, err := ioutil.ReadFile("/proc/cmdline")
+	content, err := os.ReadFile("/proc/cmdline")
 	if err != nil {
 		panic(err)
 	}
@@ -80,7 +79,7 @@ func (d dockerConfig) writeToDisk(loc string) error {
 	if err != nil {
 		return fmt.Errorf("unable to marshal docker config: %w", err)
 	}
-	if err := ioutil.WriteFile(loc, b, 0o600); err != nil {
+	if err := os.WriteFile(loc, b, 0o600); err != nil {
 		return fmt.Errorf("error writing daemon.json: %w", err)
 	}
 

--- a/hook-docker/main_test.go
+++ b/hook-docker/main_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -20,7 +19,7 @@ func TestWriteToDisk(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			// Create a temporary directory
-			dir, err := ioutil.TempDir("", "hook-docker")
+			dir, err := os.MkdirTemp("", "hook-docker")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -33,7 +32,7 @@ func TestWriteToDisk(t *testing.T) {
 			}
 
 			if tt.wantErr == nil {
-				got, err := ioutil.ReadFile(loc)
+				got, err := os.ReadFile(loc)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/lint.mk
+++ b/lint.mk
@@ -54,7 +54,7 @@ hadolint-lint: $(HADOLINT_BIN)
 	$(HADOLINT_BIN) --no-fail $(shell find . -name "*Dockerfile")
 
 GOLANGCI_LINT_CONFIG := $(LINT_ROOT)/.golangci.yml
-GOLANGCI_LINT_VERSION ?= v1.43.0
+GOLANGCI_LINT_VERSION ?= v1.50.0
 GOLANGCI_LINT_BIN := $(LINT_ROOT)/out/linters/golangci-lint-$(GOLANGCI_LINT_VERSION)-$(LINT_ARCH)
 $(GOLANGCI_LINT_BIN):
 	mkdir -p $(LINT_ROOT)/out/linters

--- a/shell.nix
+++ b/shell.nix
@@ -36,7 +36,6 @@ in mkShell {
     python3Packages.pip
     python3Packages.setuptools
     python3Packages.wheel
-    s3cmd
     shfmt
     util-linux
   ];


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This removes unused code making network calls to Hegel and updates the linter version.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #110 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
