### PR TITLE
Add proxy support for hook-bootkit and hook-docker

### DIFF
--- a/hook-bootkit/main.go
+++ b/hook-bootkit/main.go
@@ -40,6 +40,9 @@ type tinkConfig struct {
 
 	// tinkServerTLS is whether or not to use TLS for tink-server communication.
 	tinkServerTLS string
+	httpProxy string
+	httpsProxy string
+	noProxy string
 }
 
 const maxRetryAttempts = 20
@@ -83,6 +86,9 @@ func main() {
 			fmt.Sprintf("TINKERBELL_TLS=%s", cfg.tinkServerTLS),
 			fmt.Sprintf("WORKER_ID=%s", cfg.workerID),
 			fmt.Sprintf("ID=%s", cfg.workerID),
+			fmt.Sprintf("HTTP_PROXY=%s", cfg.httpProxy),
+			fmt.Sprintf("HTTPS_PROXY=%s", cfg.httpsProxy),
+			fmt.Sprintf("NO_PROXY=%s", cfg.noProxy),
 		},
 		AttachStdout: true,
 		AttachStderr: true,
@@ -125,6 +131,10 @@ func main() {
 	// Alternatively we watch for the socket being created
 	time.Sleep(time.Second * 3)
 	fmt.Println("Starting Communication with Docker Engine")
+
+	os.Setenv("HTTP_PROXY", cfg.httpProxy)
+	os.Setenv("HTTPS_PROXY", cfg.httpsProxy)
+	os.Setenv("NO_PROXY", cfg.noProxy)
 
 	// Create Docker client with API (socket)
 	ctx := context.Background()
@@ -204,6 +214,12 @@ func parseCmdLine(cmdLines []string) (cfg tinkConfig) {
 			cfg.tinkWorkerImage = cmdLine[1]
 		case "tinkerbell_tls":
 			cfg.tinkServerTLS = cmdLine[1]
+		case "HTTP_PROXY":
+			cfg.httpProxy = cmdLine[1]
+		case "HTTPS_PROXY":
+			cfg.httpsProxy = cmdLine[1]
+		case "NO_PROXY":
+			cfg.noProxy = cmdLine[1]
 		}
 	}
 	return cfg

--- a/hook-docker/main.go
+++ b/hook-docker/main.go
@@ -13,6 +13,9 @@ import (
 type tinkConfig struct {
 	syslogHost         string
 	insecureRegistries []string
+	httpProxy          string
+	httpsProxy         string
+	noProxy            string
 }
 
 type dockerConfig struct {
@@ -58,6 +61,14 @@ func main() {
 	cmd := exec.Command("/usr/local/bin/docker-init", "/usr/local/bin/dockerd")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+
+	myEnvs := make([]string, 0, 3)
+	myEnvs = append(myEnvs, fmt.Sprintf("HTTP_PROXY=%s", cfg.httpProxy))
+	myEnvs = append(myEnvs, fmt.Sprintf("HTTPS_PROXY=%s", cfg.httpsProxy))
+	myEnvs = append(myEnvs, fmt.Sprintf("NO_PROXY=%s", cfg.noProxy))
+
+	cmd.Env = append(os.Environ(), myEnvs...)
+
 	err = cmd.Run()
 	if err != nil {
 		panic(err)
@@ -90,6 +101,12 @@ func parseCmdLine(cmdLines []string) (cfg tinkConfig) {
 			cfg.syslogHost = cmdLine[1]
 		case "insecure_registries":
 			cfg.insecureRegistries = strings.Split(cmdLine[1], ",")
+		case "HTTP_PROXY":
+			cfg.httpProxy = cmdLine[1]
+		case "HTTPS_PROXY":
+			cfg.httpsProxy = cmdLine[1]
+		case "NO_PROXY":
+			cfg.noProxy = cmdLine[1]
 		}
 	}
 	return cfg


### PR DESCRIPTION
## Description

Add support for pulling docker images and specifically the tink-worker image via a proxy by configuring appropriate proxy variables via Boots.

## Why is this needed
Currently a user cannot use a proxy to pull tink-worker and container images for workflows. This PR enables proxy support for this. A user will have to pass HTTP_PROXY, HTTPS_PROXY and NO_PROXY to Boots as cli args or environment variables. These values in Boots, [extra kernel args](https://github.com/tinkerbell/boots/blob/c92674c5f39f7005602bc6882afd035dc0f13d0c/cmd/boots/main.go#L371), get populated in Hook's `/proc/cmdline` file. hook-bootkit and hook-docker will pick up those variables and set them as an environment variables in order to pull tink-worker and workflow images from a proxy server. 

Fixes: #

## How Has This Been Tested?
I have tested this changes by creating a baremetal machines using the proxy settings.


## How are existing users impacted? What migration steps/scripts do we need?
No changes are required for existing user. 


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
