### PR TITLE
Add os-release file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,12 @@ dev: dbg-image-$(ARCH) ## Build debug mode boot files and container images for c
 images: ## Build release mode boot files for all supported architectures
 push: push-hook-bootkit push-hook-docker ## Push container images to registry
 run: run-$(ARCH) ## Boot system using qemu
+
+.PHONY: update-os-release
+update-os-release: ## Update the os-release file versions
+  ## NEW_VERSION should be set from a variable passed to the make command
+  ## e.g. `make update-os-release NEW_VERSION=0.1.0`
+	for elem in VERSION VERSION_ID; do
+		sed -i "s/$${elem}=".*"/$${elem}="${NEW_VERSION}"/" hook.yaml
+	done
+	sed -i 's/PRETTY_NAME="HookOS .*"/PRETTY_NAME="HookOS ${NEW_VERSION}"/' hook.yaml

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,23 +4,36 @@ For version v0.x.y:
 
 ## Prerequisites
 
-1. Update the `VERSION`, `VERSION_ID`, and `PRETTY_NAME` values in the `hook.yaml` file under `files -> "- path: etc/os-release"` to use `0.x.y`. This can be done with:
+1. Update the `VERSION`, `VERSION_ID`, and `PRETTY_NAME` values in the `hook.yaml` file under `files -> "- path: etc/os-release"` to use `0.x.y`
 
-    ```bash
-    make update-os-release NEW_VERSION=0.x.y
-    ```
+   ```bash
+   make update-os-release NEW_VERSION=0.x.y
+   ```
 
 1. Commit, push, PR, and merge the version changes
-   - `git commit -sm "Update version to v0.x.y" hook.yaml`
+
+   ```bash
+   git commit -sm "Update version to v0.x.y" hook.yaml
+   ```
 
 ## Release Process
 
 1. Create the annotated tag
+
    > NOTE: To use your GPG signature when pushing the tag, use `SIGN_TAG=1 ./contrib/tag-release.sh v0.x.y` instead
-   - `./contrib/tag-release.sh v0.x.y`
+
+   ```bash
+   ./contrib/tag-release.sh v0.x.y
+   ```
+
 1. Push the tag to the GitHub repository. This will automatically trigger a [Github Action](https://github.com/tinkerbell/hook/actions) to create a release.
+
    > NOTE: `origin` should be the name of the remote pointing to `github.com/tinkerbell/boots`
-   - `git push origin v0.x.y`
+
+   ```bash
+   git push origin v0.x.y
+   ```
+
 1. Review the release on GitHub.
 
 ### Permissions

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,8 +1,19 @@
 # Releasing
 
-## Process
-
 For version v0.x.y:
+
+## Prerequisites
+
+1. Update the `VERSION`, `VERSION_ID`, and `PRETTY_NAME` values in the `hook.yaml` file under `files -> "- path: etc/os-release"` to use `0.x.y`. This can be done with:
+
+    ```bash
+    make update-os-release NEW_VERSION=0.x.y
+    ```
+
+1. Commit, push, PR, and merge the version changes
+   - `git commit -sm "Update version to v0.x.y" hook.yaml`
+
+## Release Process
 
 1. Create the annotated tag
    > NOTE: To use your GPG signature when pushing the tag, use `SIGN_TAG=1 ./contrib/tag-release.sh v0.x.y` instead

--- a/hook.yaml
+++ b/hook.yaml
@@ -28,6 +28,7 @@ services:
     binds.add:
       - /etc/profile.d/local.sh:/etc/profile.d/local.sh
       - /etc/motd:/etc/motd
+      - /etc/os-release:/etc/os-release
     env:
       - INSECURE=true
 
@@ -96,22 +97,37 @@ files:
     contents: |
       alias       docker='ctr -n services.linuxkit tasks exec --tty --exec-id cmd hook-docker docker'
       alias docker-shell='ctr -n services.linuxkit tasks exec --tty --exec-id shell hook-docker sh'
+      name_version=$(grep PRETTY_NAME= /etc/os-release | cut -d'=' -f2 | tr -d '"')
+      export PS1='${name_version}:\w\$ '
+      # Disable kernel messages on console
+      echo 4 > /proc/sys/kernel/printk
     mode: "0644"
 
   - path: etc/motd
     mode: "0644"
+    # This is ANSI Regular font
     contents: |
       Welcome to HookOS! Your Tinkerbell operating system installation environment.
 
-      ██   ██  ██████   ██████  ██   ██  ██████  ███████
-      ██   ██ ██    ██ ██    ██ ██  ██  ██    ██ ██
+      ██   ██                   ██       ██████  ███████
+      ██   ██  ██████   ██████  ██  ██  ██    ██ ██
       ███████ ██    ██ ██    ██ █████   ██    ██ ███████
       ██   ██ ██    ██ ██    ██ ██  ██  ██    ██      ██
       ██   ██  ██████   ██████  ██   ██  ██████  ███████
 
-      - Press `enter` to get a prompt.
       - Use `docker` commands to access the tink worker/agent container and workflow action containers.
       - Logs are located in the `/var/log/` directory.
+
+  - path: etc/os-release
+    mode: "0444"
+    contents: |
+      NAME="HookOS"
+      VERSION=0.8.1
+      ID=hookos
+      VERSION_ID=0.8.1
+      PRETTY_NAME="HookOS 0.8.1"
+      ANSI_COLOR="1;34"
+      HOME_URL="https://github.com/tinkerbell/hook"
 
   - path: etc/ip/vlan.sh
     source: "files/vlan.sh"


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This allows us to know at runtime the version of HookOS. Also, modified the prompt to contain the version so that when sharing screenshots to debug it will be clear the Hook version.

Turned down the kernel.printk log level to warning (4) so that the console Getty doesn't get messy with kernel messages. Better UX (hopefully). A side effect of this is that we won't see messages anymore on the console when workflow action containers run. Syslog messages will still be sent to Boots.

<img width="732" alt="image" src="https://github.com/tinkerbell/hook/assets/12081036/074764f3-b211-4c34-91f2-6d27511be212">


## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #176 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
