### PR TITLE
Update sed command for getting vlan_id from cmdline:

### DIFF
--- a/files/dhcp.sh
+++ b/files/dhcp.sh
@@ -11,7 +11,7 @@ run_dhcp_client() {
 	one_shot="$1"
 	al="eth*"
 
-	vlan_id=$(sed -n 's/.*vlan_id=\([0-9]*\).*/\1/p' /proc/cmdline)
+	vlan_id=$(sed -n 's/.* vlan_id=\([0-9]*\).*/\1/p' /proc/cmdline)
 	if [ -n "$vlan_id" ]; then
 		al="eth*.*"
 	fi


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This fixes an issue where "vlan_id" is a substring. For example: "thisisavlan_id=123". This example will be treated as if the vlan_id was not set at all.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #180 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
