### PR TITLE
Adding support for a poweroff watcher

### DIFF
--- a/hook-docker/main.go
+++ b/hook-docker/main.go
@@ -122,7 +122,7 @@ func parseCmdLine(cmdLines []string) (cfg tinkConfig) {
 }
 
 func rebootWatch() {
-	fmt.Println("Starting Reboot Watcher")
+	fmt.Println("Starting Reboot / Poweroff Watcher")
 
 	// Forever loop
 	for {
@@ -136,12 +136,26 @@ func rebootWatch() {
 				time.Sleep(time.Second)
 				continue
 			}
+			fmt.Println("Rebooting")
+			break
+		}
+
+		if fileExists("/worker/poweroff") {
+			cmd := exec.Command("/sbin/poweroff")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			err := cmd.Run()
+			if err != nil {
+				fmt.Printf("error calling /sbin/poweroff: %v\n", err)
+				time.Sleep(time.Second)
+				continue
+			}
+			fmt.Println("Powering Off")
 			break
 		}
 		// Wait one second before looking for file
 		time.Sleep(time.Second)
 	}
-	fmt.Println("Rebooting")
 }
 
 func fileExists(filename string) bool {


### PR DESCRIPTION
## Description

Expands the existing reboot watcher to provide support to power off the host system. Executes /sbin/poweroff once /worker/poweroff is written to disk

## Why is this needed

Fixes: (https://github.com/tinkerbell/hook/issues/189)

## How Has This Been Tested?
I am unable to build hook locally so this is untested.

## How are existing users impacted? What migration steps/scripts do we need?

No impact
