### PR TITLE
Update apk repository for kexec-tools

### DIFF
--- a/hook-docker/Dockerfile
+++ b/hook-docker/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /src
 RUN CGO_ENABLED=0 go build -a -ldflags '-w -extldflags "-static"' -o /hook-docker
 
 FROM docker:24.0.4-dind
-RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
 RUN apk update; apk add kexec-tools
 COPY --from=dev /hook-docker .
 ENTRYPOINT ["/hook-docker"]


### PR DESCRIPTION
## Description

kexec-tools has been promoted from edge/testing to edge/community. This PR updates the repository in the hook-docker Dockerfile.

For reference: https://git.alpinelinux.org/aports/commit/community/kexec-tools/APKBUILD?id=eccd9de1410cd384891105da4bedb05b7db44744

## Why is this needed

Builds will fail because the kexec-package cannot be installed:

```
#7 2.121 ERROR: unable to select packages:
#7 2.121   kexec-tools (no such package):
#7 2.121     required by: world[kexec-tools]
------
Dockerfile:8
--------------------
   6 |     FROM docker:24.0.4-dind
   7 |     RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
   8 | >>> RUN apk update; apk add kexec-tools
   9 |     COPY --from=dev /hook-docker .
  10 |     ENTRYPOINT ["/hook-docker"]
--------------------
error: failed to solve: process "/bin/sh -c apk update; apk add kexec-tools" did not complete successfully: exit code: 1
make: *** [rules.mk:81: out/sha-4b355bc/hook-docker-amd64] Error 1
```

## How Has This Been Tested?

I successfully ran `make containers`:

```
#15 importing to docker                                                                                                       
#15 DONE 0.7s                                                                                                                 
                               
#14 exporting to docker image format
#14 sending tarball 1.8s done                                                                                                 
#14 DONE 3.2s
```

## How are existing users impacted? What migration steps/scripts do we need?

No and None

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
