### PR TITLE
Revert "Dont use arch in container image tag:"

### DIFF
--- a/bash/hook-lk-containers.sh
+++ b/bash/hook-lk-containers.sh
@@ -22,7 +22,7 @@ function build_hook_linuxkit_container() {
 	container_files_hash="$(find "${container_dir}" -type f -print | LC_ALL=C sort | xargs sha256sum | sha256sum | cut -d' ' -f1)"
 	declare container_files_hash_short="${container_files_hash:0:8}"
 
-	declare container_oci_ref="${HOOK_LK_CONTAINERS_OCI_BASE}${container_dir}:${container_files_hash_short}"
+	declare container_oci_ref="${HOOK_LK_CONTAINERS_OCI_BASE}${container_dir}:${container_files_hash_short}-${DOCKER_ARCH}"
 	log info "Consider building LK container ${container_oci_ref} from ${container_dir} for platform ${DOCKER_ARCH}"
 	output_var="${container_oci_ref}" # the the name reference
 	echo "${output_var}" > /dev/null  # no-op; just to avoid shellcheck SC2034 (unused var; but it is actually a bash nameref)


### PR DESCRIPTION
#### Revert "Dont use arch in container image tag:"

- This reverts commit 69a4c8725cd0a3585e40188ac82b262984c991f4:
> "The service containers we build shouldnt use arch in the tags. This way the same tag will have mulitple archs at the registry layer."
- this isn't really true, as can be seen from the --platform argument to buildx; also the GHA matrix'es are split per-arch
- effectively, we had random arch (but not both) in each tag, depending on build speed/order in GHA
- causes `Error creating 000-rngd1: fork/exec /usr/bin/runc: exec format error` (and many others) depending on luck or lack thereof
