### PR TITLE
build: armbian kernels: use inventory_id (sans "armbian-" prefix) in kernel tag name

### DIFF
--- a/bash/kernel/kernel_armbian.sh
+++ b/bash/kernel/kernel_armbian.sh
@@ -103,8 +103,8 @@ function calculate_kernel_version_armbian() {
 	input_hash="$(cat "${ARMBIAN_KERNEL_DOCKERFILE}" | sha256sum - | cut -d ' ' -f 1)"
 	short_input_hash="${input_hash:0:8}"
 	kernel_oci_version="${ARMBIAN_KERNEL_MAJOR_MINOR_POINT}-${short_input_hash}"
-	armbian_type="$( echo "${inventory_id}" | cut -d "-" -f 2 )"
-	kernel_oci_image="${HOOK_KERNEL_OCI_BASE}-armbian:${kernel_oci_version}"-"${armbian_type}"
+	armbian_type="${inventory_id#"armbian-"}" # remove the 'armbian-' prefix from inventory_id, but keep the rest. "uefi" has "current/edge" and "arm64/x86" variants.
+	kernel_oci_image="${HOOK_KERNEL_OCI_BASE}-armbian:${kernel_oci_version}-${armbian_type}"
 	log info "kernel_oci_version: ${kernel_oci_version}"
 	log info "kernel_oci_image: ${kernel_oci_image}"
 }


### PR DESCRIPTION
#### build: armbian kernels: use inventory_id (sans "armbian-" prefix) in kernel tag name

- previous approach only took the 2nd dash-field, which is not enough to uniquely identify kernels
- avoid `uefi-x86-edge` and `uefi-arm64-edge` both competing for `uefi`

Signed-off-by: Ricardo Pardini <ricardo@pardini.net>