### PR TITLE
rpardini's May'24 fix batch: slim for 2Gb RAM devices

### DIFF
--- a/bash/json-matrix.sh
+++ b/bash/json-matrix.sh
@@ -73,7 +73,7 @@ function prepare_json_matrix() {
 
 		if [[ "${matrix_type}" == "KERNEL" ]]; then # special case for kernel builds, if USE_KERNEL_ID is set, skip this kernel
 			if [[ -n "${kernel_info[USE_KERNEL_ID]}" ]]; then
-				log warn "Skipping build of kernel '${kernel}' due to it having USE_KERNEL_ID set to '${kernel_info[USE_KERNEL_ID]}'"
+				log info "Skipping build of kernel '${kernel}' due to it having USE_KERNEL_ID set to '${kernel_info[USE_KERNEL_ID]}'"
 				continue
 			fi
 		fi

--- a/bash/kernel/kernel_armbian.sh
+++ b/bash/kernel/kernel_armbian.sh
@@ -94,6 +94,11 @@ function calculate_kernel_version_armbian() {
 		# Important: this tarball needs to have permissions for the root directory included! Otherwise linuxkit rootfs will have the wrong permissions on / (root)
 		WORKDIR /armbian/modules_only
 		RUN mv /armbian/image/lib /armbian/modules_only/
+		RUN echo "Before cleaning: " && du -h -d 10 -x . | sort -h | tail -n 20
+		# Trim the kernel modules to save space; hopefully your required hardware is not included here
+		RUN rm -rfv ./lib/modules/*/kernel/drivers/net/wireless ./lib/modules/*/kernel/sound ./lib/modules/*/kernel/drivers/media
+		RUN rm -rfv ./lib/modules/*/kernel/drivers/infiniband
+		RUN echo "After cleaning: " &&  du -h -d 10 -x . | sort -h | tail -n 20
 		RUN tar -cf /armbian/output/kernel.tar .
 
 		# Create a tarball with the dtbs in usr/lib/linux-image-*

--- a/bash/kernel/kernel_armbian.sh
+++ b/bash/kernel/kernel_armbian.sh
@@ -94,7 +94,7 @@ function calculate_kernel_version_armbian() {
 		# Important: this tarball needs to have permissions for the root directory included! Otherwise linuxkit rootfs will have the wrong permissions on / (root)
 		WORKDIR /armbian/modules_only
 		RUN mv /armbian/image/lib /armbian/modules_only/
-		RUN tar -cvf /armbian/output/kernel.tar .
+		RUN tar -cf /armbian/output/kernel.tar .
 
 		# Create a tarball with the dtbs in usr/lib/linux-image-*
 		RUN { cd usr/lib/linux-image-* || { echo "No DTBS for this arch, empty tar..." && mkdir -p usr/lib/linux-image-no-dtbs && cd usr/lib/linux-image-* ; } ; }  && pwd && du -h -d 1 . && tar -czvf /armbian/output/dtbs.tar.gz . && ls -lah /armbian/output/dtbs.tar.gz

--- a/bash/kernel/kernel_armbian.sh
+++ b/bash/kernel/kernel_armbian.sh
@@ -90,8 +90,11 @@ function calculate_kernel_version_armbian() {
 		# Get the kernel image...
 		RUN cp -v boot/vmlinuz* /armbian/output/kernel
 
-		# Create a tarball with the modules in lib
-		RUN tar -cvf /armbian/output/kernel.tar lib
+		# Create a tarball with the modules in lib.
+		# Important: this tarball needs to have permissions for the root directory included! Otherwise linuxkit rootfs will have the wrong permissions on / (root)
+		WORKDIR /armbian/modules_only
+		RUN mv /armbian/image/lib /armbian/modules_only/
+		RUN tar -cvf /armbian/output/kernel.tar .
 
 		# Create a tarball with the dtbs in usr/lib/linux-image-*
 		RUN { cd usr/lib/linux-image-* || { echo "No DTBS for this arch, empty tar..." && mkdir -p usr/lib/linux-image-no-dtbs && cd usr/lib/linux-image-* ; } ; }  && pwd && du -h -d 1 . && tar -czvf /armbian/output/dtbs.tar.gz . && ls -lah /armbian/output/dtbs.tar.gz

--- a/bash/kernel/kernel_armbian.sh
+++ b/bash/kernel/kernel_armbian.sh
@@ -45,8 +45,15 @@ function calculate_kernel_version_armbian() {
 
 	declare -g ARMBIAN_KERNEL_DOCKERFILE="kernel/Dockerfile.autogen.armbian.${inventory_id}"
 
-	declare oras_version="1.2.0-beta.1" # @TODO bump this once it's released; yes it's much better than 1.1.x's
-	declare oras_down_url="https://github.com/oras-project/oras/releases/download/v${oras_version}/oras_${oras_version}_linux_amd64.tar.gz"
+	declare oras_version="1.2.0-rc.1" # @TODO bump this once it's released; yes it's much better than 1.1.x's
+	# determine the arch to download from current arch
+	declare oras_arch="unknown"
+	case "$(uname -m)" in
+		"x86_64") oras_arch="amd64" ;;
+		"aarch64") oras_arch="arm64" ;;
+		*) log error "ERROR: ARCH $(uname -m) not supported by ORAS? check https://github.com/oras-project/oras/releases" && exit 1 ;;
+	esac
+	declare oras_down_url="https://github.com/oras-project/oras/releases/download/v${oras_version}/oras_${oras_version}_linux_${oras_arch}.tar.gz"
 
 	# Lets create a Dockerfile that will be used to obtain the artifacts needed, using ORAS binary
 	echo "Creating Dockerfile '${ARMBIAN_KERNEL_DOCKERFILE}'... "

--- a/images/hook-bootkit/Dockerfile
+++ b/images/hook-bootkit/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.21-alpine as dev
 COPY . /src/
 WORKDIR /src
 RUN go mod download
-RUN CGO_ENABLED=0 go build -a -ldflags '-w -extldflags "-static"' -o /bootkit
+RUN CGO_ENABLED=0 go build -a -ldflags '-s -w -extldflags "-static"' -o /bootkit
 
 FROM alpine
 COPY --from=dev /bootkit .

--- a/images/hook-containerd/Dockerfile
+++ b/images/hook-containerd/Dockerfile
@@ -18,7 +18,7 @@ RUN mkdir -p $GOPATH/src/github.com/containerd && \
   git checkout $CONTAINERD_COMMIT
 RUN apk add --no-cache btrfs-progs-dev gcc libc-dev linux-headers make libseccomp-dev
 WORKDIR $GOPATH/src/github.com/containerd/containerd
-RUN make binaries EXTRA_FLAGS="-buildmode pie" EXTRA_LDFLAGS='-extldflags "-fno-PIC -static"' BUILDTAGS="static_build no_devmapper"
+RUN make binaries EXTRA_FLAGS="-buildmode pie" EXTRA_LDFLAGS='-w -s -extldflags "-fno-PIC -static"' BUILDTAGS="static_build no_devmapper"
 
 # install nerdctl
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=amd64; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; else ARCHITECTURE=amd64; fi \

--- a/images/hook-docker/Dockerfile
+++ b/images/hook-docker/Dockerfile
@@ -1,10 +1,16 @@
 FROM golang:1.20-alpine as dev
 COPY . /src/
 WORKDIR /src
-RUN CGO_ENABLED=0 go build -a -ldflags '-w -extldflags "-static"' -o /hook-docker
+RUN CGO_ENABLED=0 go build -a -ldflags '-s -w -extldflags "-static"' -o /hook-docker
 
 FROM docker:26.1.0-dind
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
-RUN apk update; apk add kexec-tools
+RUN apk update && apk add kexec-tools binutils && rm -rf /var/cache/apk/*
+# Won't use docker-buildx nor docker-compose
+RUN rm -rf /usr/local/libexec/docker/cli-plugins
+# Strip some large binaries
+RUN strip /usr/local/bin/docker /usr/local/bin/dockerd /usr/local/bin/docker-proxy /usr/local/bin/runc
+# Purge binutils package after stripping
+RUN apk del binutils
 COPY --from=dev /hook-docker .
 ENTRYPOINT ["/hook-docker"]

--- a/images/hook-mdev/Dockerfile
+++ b/images/hook-mdev/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine
 
 USER root:root
 
-RUN apk add --no-cache mdev-conf
+RUN apk add --no-cache mdev-conf && rm -rf /var/cache/apk/*
 
 CMD ["mdev", "-v", "-df"]
 

--- a/images/hook-runc/Dockerfile
+++ b/images/hook-runc/Dockerfile
@@ -19,7 +19,7 @@ RUN mkdir -p $GOPATH/src/github.com/opencontainers && \
   git clone https://github.com/opencontainers/runc.git
 WORKDIR $GOPATH/src/github.com/opencontainers/runc
 RUN git checkout $RUNC_COMMIT
-RUN make static BUILDTAGS="seccomp" EXTRA_FLAGS="-buildmode pie" EXTRA_LDFLAGS="-extldflags \\\"-fno-PIC -static\\\""
+RUN make static BUILDTAGS="seccomp" EXTRA_FLAGS="-buildmode pie" EXTRA_LDFLAGS="-s -w -extldflags \\\"-fno-PIC -static\\\""
 RUN cp runc /usr/bin/
 
 RUN mkdir -p /etc/init.d && ln -s /usr/bin/service /etc/init.d/010-onboot

--- a/linuxkit-templates/hook.template.yaml
+++ b/linuxkit-templates/hook.template.yaml
@@ -134,6 +134,16 @@ services:
       major: 204
       minor: 65
       mode: "0666"
+    - path: "/dev/ttyAML0"
+      type: c
+      major: 243
+      minor: 0
+      mode: "0666"
+    - path: "/dev/ttyAML1"
+      type: c
+      major: 243
+      minor: 1
+      mode: "0666"
 
   - name: hook-docker
     image: "${HOOK_CONTAINER_DOCKER_IMAGE}"
@@ -266,6 +276,8 @@ files:
       ttyS1
       ttyAMA0
       ttyAMA1
+      ttyAML0
+      ttyAML1
       ttyUSB0
       ttyUSB1
       ttyUSB2


### PR DESCRIPTION
> - recent userspace additions took the initramfs size near or over the 900mb mark for certain kernels.
> - initramfs (gzipped cpio) is uncompressed by bootloader and mounted on tmpfs by kernel.
> - tmpfs allows only 50% of physical RAM by default, and default can't be changed easily.
> - slim down both the userspace (by stripping / removing some / etc) and the Armbian kernels (by removing modules)
> - with those we're back below 900mb uncompressed again, and the default x86 hook tarball is down from 223 to 180mb compressed.
> - add a check for uncompressed cpio size at 900mb; warn in GHA if it is ever hit again.
> - also includes: fixes for ttyAML consoles, better logging, some dev/debug options used for batch
> 
> note: review is easier if done commit-by-commit; sent a large batch due to same-line changes across them

----

#### build: common: better logging & emit notice/warn/error also to GHA workflow commands

- see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-a-notice-message
- introduces `notice` level, which is just like `info` but brighter and goes to GHA
- also: curb warning about USE_KERNEL_ID down to info


#### kernel: armbian: fix: use ORAS binary appropriate to the (host) arch; bump ORAS to 1.2.0-rc.1 (from beta.1)

- otherwise can't build those "kernels" on arm64-only & qemu+binfmt-deprived hosts


#### build: introduce `OUTPUT_TARBALL_FILELIST=yes` to include LK's `--format tar` output and its filelist

- useful during development for:
  - debugging esoteric issue with file permissions
  - checking the space usage distribution, so we can slim down where needed


#### kernel: armbian: ensure kernel.tar contains entry for the / (root) directory

- quite esoteric, but it seems LinuxKit uses the kernel.tar's root entry as its own entry
- if that is missing, then the final product rootfs will have root dir with very strange permissions


#### kernel: armbian: don't flood output with tar's verbose option


#### kernel: armbian: remove some heavy kernel modules (so it fits in 2Gb RAM)

- Armbian kernels are meant for general-purpose initrd's, and including all modules is overkill
- this allows to boot on 2Gb RAM machines (tmpfs allows only up to 50% RAM)


#### images: slim down golang binaries, by building without DWARF/debug symbols, stripping prebuilts, and removing unneeded bins

- strip golang binaries (both during build with ldflags and prebuilt ones with 'strip'/binutils)
- don't ship apk caches
- we won't use docker-buildx nor docker-compose bins, which are huge; remove them
- remove stray 'hook-bootkit' binary from source directory (leftover from ?)


#### hook: add handling for ttyAML0/1 (used on Amlogic SoCs)

- complements a68b6296f31c2abb63ba6f227d694f1328ccc6c8
- create /dev devices with 243 major and 0/1 minor
- add to securetty


#### build: introduce check for initramfs size > 900Mb and warn/notice

- those will most likely fail to boot on 2Gb RAM machines
  - initramfs will by default use tmpfs (which defaults to 50% ram), not ramfs


