### PR TITLE
hook: add ttyUSB0/ttyUSB1 to getty consoles list

### DIFF
--- a/linuxkit-templates/hook.template.yaml
+++ b/linuxkit-templates/hook.template.yaml
@@ -144,6 +144,16 @@ services:
       major: 243
       minor: 1
       mode: "0666"
+    - path: "/dev/ttyUSB0"
+      type: c
+      major: 188
+      minor: 0
+      mode: "0666"
+    - path: "/dev/ttyUSB1"
+      type: c
+      major: 188
+      minor: 1
+      mode: "0666"
 
   - name: hook-docker
     image: "${HOOK_CONTAINER_DOCKER_IMAGE}"


### PR DESCRIPTION
#### hook: add ttyUSB0/ttyUSB1 to getty consoles list

- ttyUSB0 is useful when handling machines without onboard tty, eg, laptops (use a ttl-dongle pair)

Signed-off-by: Ricardo Pardini <ricardo@pardini.net>