### PR TITLE
build: gha: always use GHA cache for Linuxkit Cache in hopes of diminishing DockerHub pull-rate limits trouble

### DIFF
--- a/.github/workflows/build-all-matrix.yaml
+++ b/.github/workflows/build-all-matrix.yaml
@@ -151,7 +151,7 @@ jobs:
 
       - name: GitHub Actions Cache for 'cache' dir
         uses: actions/cache@v4
-        if: ${{ matrix.gha_cache == 'yes' }} # only set to yes for GH-hosted runners; see gha-matrix bash impl
+        if: ${{ matrix.gha_cache == 'yes' }} # effectively always yes: see gha_cache in bash/json-matrix.sh around line 84
         with:
           path: cache
           key: "lk-cache-${{ matrix.docker_arch }}-${{ matrix.kernel }}-${{ hashFiles('linuxkit-templates/*') }}-${{ hashFiles('bash/**/*.sh') }}"

--- a/bash/json-matrix.sh
+++ b/bash/json-matrix.sh
@@ -81,10 +81,7 @@ function prepare_json_matrix() {
 		if json_matrix_tag_match "${kernel_info[TAG]}"; then
 			declare runner="unknown-runner"
 			runner="$(json_matrix_find_runner "${matrix_type}" "${kernel_info[DOCKER_ARCH]}")"
-			declare gha_cache="no"                              # default to not using a GHA cache
-			if [[ "${runner}" == "[\"ubuntu-latest\"]" ]]; then # enable cache if using a GH-hosted runner
-				gha_cache="yes"
-			fi
+			declare gha_cache="yes" # always use GH cache; hitting DockerHub for linuxkit images is prone to rate limiting
 
 			all_arches["${kernel_info[DOCKER_ARCH]}"]=1
 			json_items+=("{\"kernel\":\"${kernel}\",\"arch\":\"${kernel_info[ARCH]}\",\"docker_arch\":\"${kernel_info[DOCKER_ARCH]}\",\"runner\":${runner},\"gha_cache\":\"${gha_cache}\"}")


### PR DESCRIPTION
#### build: gha: always use GHA cache for Linuxkit Cache in hopes of diminishing DockerHub pull-rate limits trouble

- previously, it only used GHA cache for builds running on GH-hosted runners
- this now enables it for all builds, even on self-hosted runners
- next few builds might still fail, but further ones will have a cache (we've `save-always: true`) and should eventually work

Signed-off-by: Ricardo Pardini <ricardo@pardini.net>