### PR TITLE
Update build script to facilitate iso builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ The most important environment variables are:
   - `HOOK_LK_CONTAINERS_OCI_BASE`: OCI base coordinates for the LinuxKit containers.
   - `CACHE_DIR`: directory where the build system will cache downloaded files. Relative to the project root.
   - `USE_LATEST_BUILT_KERNEL`: set this to `yes` to use the latest built kernel from `quay.io/tinkerbell/hook-kernel`.
+  - `LINUXKIT_ISO`: set this to `yes` to build an ISO image instead of a kernel and initrd.
 - exclusively for the `qemu` command:
   - `TINK_SERVER=<ip>`: the IP address of the Tinkerbell GRPC server. No default.
   - `MAC=<mac>`: the MAC address of the machine that will be provisioned. No default.

--- a/bash/linuxkit.sh
+++ b/bash/linuxkit.sh
@@ -83,23 +83,6 @@ function linuxkit_build() {
 	declare lk_cache_dir="${CACHE_DIR}/linuxkit"
 	mkdir -p "${lk_cache_dir}"
 
-	declare -a lk_args=(
-		"--docker"
-		"--arch" "${kernel_info['DOCKER_ARCH']}"
-		"--name" "hook"
-		"--cache" "${lk_cache_dir}"
-		"--dir" "${lk_output_dir}"
-		"hook.${inventory_id}.yaml" # the linuxkit configuration file
-	)
-
-	if [[ "${OUTPUT_TARBALL_FILELIST:-"no"}" == "yes" ]]; then
-		log info "OUTPUT_TARBALL_FILELIST=yes; Building Hook (tar/filelist) with kernel ${inventory_id} using linuxkit: ${lk_args[*]}"
-		"${linuxkit_bin}" build "--format" "tar" "${lk_args[@]}"
-	fi
-
-	log info "Building Hook with kernel ${inventory_id} using linuxkit: ${lk_args[*]}"
-	"${linuxkit_bin}" build "--format" "kernel+initrd" "${lk_args[@]}"
-
 	# if LINUXKIT_ISO is set, build an ISO with the kernel and initramfs
 	if [[ -n "${LINUXKIT_ISO}" ]]; then
 		declare lk_iso_output_dir="out"
@@ -117,7 +100,25 @@ function linuxkit_build() {
 
 		log info "Building Hook ISO with kernel ${inventory_id} using linuxkit: ${lk_iso_args[*]}"
 		"${linuxkit_bin}" build "${lk_iso_args[@]}"
+		return 0
 	fi
+	
+	declare -a lk_args=(
+		"--docker"
+		"--arch" "${kernel_info['DOCKER_ARCH']}"
+		"--name" "hook"
+		"--cache" "${lk_cache_dir}"
+		"--dir" "${lk_output_dir}"
+		"hook.${inventory_id}.yaml" # the linuxkit configuration file
+	)
+
+	if [[ "${OUTPUT_TARBALL_FILELIST:-"no"}" == "yes" ]]; then
+		log info "OUTPUT_TARBALL_FILELIST=yes; Building Hook (tar/filelist) with kernel ${inventory_id} using linuxkit: ${lk_args[*]}"
+		"${linuxkit_bin}" build "--format" "tar" "${lk_args[@]}"
+	fi
+
+	log info "Building Hook with kernel ${inventory_id} using linuxkit: ${lk_args[*]}"
+	"${linuxkit_bin}" build "--format" "kernel+initrd" "${lk_args[@]}"
 
 	declare initramfs_path="${lk_output_dir}/hook-initrd.img"
 	# initramfs_path is a gzipped file. obtain the uncompressed byte size, without decompressing it

--- a/bash/linuxkit.sh
+++ b/bash/linuxkit.sh
@@ -100,6 +100,25 @@ function linuxkit_build() {
 	log info "Building Hook with kernel ${inventory_id} using linuxkit: ${lk_args[*]}"
 	"${linuxkit_bin}" build "--format" "kernel+initrd" "${lk_args[@]}"
 
+	# if LINUXKIT_ISO is set, build an ISO with the kernel and initramfs
+	if [[ -n "${LINUXKIT_ISO}" ]]; then
+		declare lk_iso_output_dir="out"
+		mkdir -p "${lk_iso_output_dir}"
+
+		declare -a lk_iso_args=(
+			"--docker"
+			"--arch" "${kernel_info['DOCKER_ARCH']}"
+			"--format" "iso-efi-initrd"
+			"--name" "hook"
+			"--cache" "${lk_cache_dir}"
+			"--dir" "${lk_iso_output_dir}"
+			"hook.${inventory_id}.yaml" # the linuxkit configuration file
+		)
+
+		log info "Building Hook ISO with kernel ${inventory_id} using linuxkit: ${lk_iso_args[*]}"
+		"${linuxkit_bin}" build "${lk_iso_args[@]}"
+	fi
+
 	declare initramfs_path="${lk_output_dir}/hook-initrd.img"
 	# initramfs_path is a gzipped file. obtain the uncompressed byte size, without decompressing it
 	declare -i initramfs_size_bytes=0


### PR DESCRIPTION
## Description
Linuxkit also offers an option to build kernel as an iso file. Update the build script to be able Hook as an ISO. 

## Why is this needed
Apart from the default build, this change provides the users to be able to mount Hook as an ISO and boot using the virtual media option. 


Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Set `LINUXKIT_ISO` to true and built hook as an ISO. Mounted the ISO on a Dell R340 as a virtual media device and booted using the ISO. As this flow kicks in only when the above env var is set, it should affect any existing user workflow. 

## Checklist:
If this gets approved, I will update the Readme appropriately to document the option to build as an ISO.

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
