### PR TITLE
batch of fixes and enhancements - early january'2025

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = tab
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.sh]
+shell_variant = bash
+binary_next_line = false
+switch_case_indent = true
+ij_shell_switch_cases_indented = true
+space_redirects = true
+keep_padding = false
+function_next_line = false

--- a/.github/workflows/build-all-matrix.yaml
+++ b/.github/workflows/build-all-matrix.yaml
@@ -51,9 +51,8 @@ jobs:
         id: date_prep
         run: echo "created=$(date -u +'%Y%m%d-%H%M')" >> "${GITHUB_OUTPUT}"
 
-      - name: Run shellcheck # so fail fast in case of bash errors/warnings
-        id: shellcheck
-        run: bash build.sh shellcheck
+      - name: Run lint (shellcheck/shellfmt) # so fail fast in case of bash errors/warnings or unformatted code
+        run: bash build.sh lint
 
       - name: Run the matrix JSON preparation bash script
         id: prepare-matrix

--- a/bash/docker.sh
+++ b/bash/docker.sh
@@ -23,3 +23,58 @@ function check_docker_daemon_for_sanity() {
 	}
 
 }
+
+# Utility to pull skopeo itself from SKOPEO_IMAGE; checks the local Docker cache and skips if found
+function pull_skopeo_image_if_not_in_local_docker_cache() {
+	# Check if the image is already in the local Docker cache
+	if docker image inspect "${SKOPEO_IMAGE}" &> /dev/null; then
+		log info "Skopeo image ${SKOPEO_IMAGE} is already in the local Docker cache; skipping pull."
+		return 0
+	fi
+
+	log info "Pulling Skopeo image ${SKOPEO_IMAGE}..."
+
+	pull_docker_image_from_remote_with_retries "${SKOPEO_IMAGE}"
+}
+
+# Utility to get the most recent tag for a given image, using Skopeo. no retries, a failure is fatal.
+# Sets the value of outer-scope variable latest_tag_for_docker_image, so declare it there.
+# If extra arguments are present after the image, they are used to grep the tags.
+function get_latest_tag_for_docker_image_using_skopeo() {
+	declare image="$1"
+	shift
+	latest_tag_for_docker_image="undetermined_tag"
+
+	# Pull separately to avoid tty hell in the subshell below
+	pull_skopeo_image_if_not_in_local_docker_cache
+
+	# if extra arguments are present, use them to grep the tags
+	if [[ -n "$*" ]]; then
+		latest_tag_for_docker_image="$(docker run "${SKOPEO_IMAGE}" list-tags "docker://${image}" | jq -r ".Tags[]" | grep "${@}" | tail -1)"
+	else
+		latest_tag_for_docker_image="$(docker run "${SKOPEO_IMAGE}" list-tags "docker://${image}" | jq -r ".Tags[]" | tail -1)"
+	fi
+	log info "Found latest tag: '${latest_tag_for_docker_image}' for image '${image}'"
+}
+
+# Utility to pull from remote, with retries.
+function pull_docker_image_from_remote_with_retries() {
+	declare image="$1"
+	declare -i retries=3
+	declare -i retry_delay=5
+	declare -i retry_count=0
+
+	while [[ ${retry_count} -lt ${retries} ]]; do
+		if docker pull "${image}"; then
+			log info "Successfully pulled ${image}"
+			return 0
+		else
+			log warn "Failed to pull ${image}; retrying in ${retry_delay} seconds..."
+			sleep "${retry_delay}"
+			((retry_count += 1))
+		fi
+	done
+
+	log error "Failed to pull ${image} after ${retries} retries."
+	exit 1
+}

--- a/bash/docker.sh
+++ b/bash/docker.sh
@@ -10,6 +10,9 @@ function check_docker_daemon_for_sanity() {
 	log debug "Setting DOCKER_HOST to '${current_context_docker_socket}'"
 	export DOCKER_HOST="${current_context_docker_socket}"
 
+	# Hide Docker, Inc spamming "What's next" et al.
+	export DOCKER_CLI_HINTS=false
+
 	# Shenanigans to go around error control & capture output in the same effort, 'docker info' is slow.
 	declare docker_info docker_buildx_version
 	docker_info="$({ docker info 2> /dev/null && echo "DOCKER_INFO_OK"; } || true)"

--- a/bash/hook-lk-containers.sh
+++ b/bash/hook-lk-containers.sh
@@ -66,7 +66,6 @@ function build_hook_linuxkit_container() {
 	return 0
 }
 
-
 function push_hook_linuxkit_container() {
 	declare container_oci_ref="${1}"
 

--- a/bash/kernel.sh
+++ b/bash/kernel.sh
@@ -33,7 +33,7 @@ function kernel_build() {
 	log debug "Kernel build method: ${kernel_info[BUILD_FUNC]}"
 	"${kernel_info[BUILD_FUNC]}"
 
-	# Push it to the OCI registry
+	# Push it to the OCI registry; this discards the os/arch information that BuildKit generates
 	if [[ "${DO_PUSH:-"no"}" == "yes" ]]; then
 		log info "Kernel built; pushing to ${kernel_oci_image}"
 		docker push "${kernel_oci_image}"

--- a/bash/kernel/kernel_armbian.sh
+++ b/bash/kernel/kernel_armbian.sh
@@ -58,7 +58,7 @@ function calculate_kernel_version_armbian() {
 	# Lets create a Dockerfile that will be used to obtain the artifacts needed, using ORAS binary
 	echo "Creating Dockerfile '${ARMBIAN_KERNEL_DOCKERFILE}'... "
 	cat <<- ARMBIAN_ORAS_DOCKERFILE > "${ARMBIAN_KERNEL_DOCKERFILE}"
-		FROM debian:stable as downloader
+		FROM debian:stable AS downloader
 		# Install ORAS binary tool from GitHub releases
 		ENV DEBIAN_FRONTEND=noninteractive
 		RUN apt -o "Dpkg::Use-Pty=0" update && apt install -o "Dpkg::Use-Pty=0" -y curl dpkg-dev && \
@@ -67,7 +67,7 @@ function calculate_kernel_version_armbian() {
 		      chmod +x /usr/local/bin/oras && \
 		      oras version
 
-		FROM downloader as downloaded
+		FROM downloader AS downloaded
 
 		# lets create the output dir
 		WORKDIR /armbian/output

--- a/bash/kernel/kernel_default.sh
+++ b/bash/kernel/kernel_default.sh
@@ -131,9 +131,8 @@ function build_kernel_default() {
 	common_build_args_kernel_default
 	log info "Will build with: ${build_args[*]}"
 
-	(
-		cd kernel
-		docker buildx build --load "--progress=${DOCKER_BUILDX_PROGRESS_TYPE}" "${build_args[@]}" -t "${kernel_oci_image}" .
-	)
-
+	# Don't specify platform, our Dockerfile is multiarch, thus you can build x86 kernels in arm64 hosts and vice-versa ...
+	docker buildx build --load "--progress=${DOCKER_BUILDX_PROGRESS_TYPE}" "${build_args[@]}" -t "${kernel_oci_image}" -f kernel/Dockerfile kernel
+	# .. but enforce the target arch for LK in the final image via dump/edit-manifests/reimport trick
+	ensure_docker_image_architecture "${kernel_oci_image}" "${kernel_info['DOCKER_ARCH']}"
 }

--- a/bash/linuxkit.sh
+++ b/bash/linuxkit.sh
@@ -93,6 +93,11 @@ function linuxkit_build() {
 	declare lk_cache_dir="${CACHE_DIR}/linuxkit"
 	mkdir -p "${lk_cache_dir}"
 
+	declare -a lk_debug_args=()
+	if [[ "${DEBUG}" == "yes" ]]; then
+		lk_debug_args+=("--verbose" "2") # 0 = quiet, 1 = info, 2 = debug, 3 = trace.
+	fi
+
 	# if LINUXKIT_ISO is set, build an ISO with the kernel and initramfs
 	if [[ -n "${LINUXKIT_ISO}" ]]; then
 		declare lk_iso_output_dir="out"
@@ -109,7 +114,7 @@ function linuxkit_build() {
 		)
 
 		log info "Building Hook ISO with kernel ${inventory_id} using linuxkit: ${lk_iso_args[*]}"
-		"${linuxkit_bin}" build "${lk_iso_args[@]}"
+		"${linuxkit_bin}" build "${lk_debug_args[@]}" "${lk_iso_args[@]}"
 		return 0
 	fi
 
@@ -124,11 +129,11 @@ function linuxkit_build() {
 
 	if [[ "${OUTPUT_TARBALL_FILELIST:-"no"}" == "yes" ]]; then
 		log info "OUTPUT_TARBALL_FILELIST=yes; Building Hook (tar/filelist) with kernel ${inventory_id} using linuxkit: ${lk_args[*]}"
-		"${linuxkit_bin}" build "--format" "tar" "${lk_args[@]}"
+		"${linuxkit_bin}" build "--format" "tar" "${lk_debug_args[@]}" "${lk_args[@]}"
 	fi
 
 	log info "Building Hook with kernel ${inventory_id} using linuxkit: ${lk_args[*]}"
-	"${linuxkit_bin}" build "--format" "kernel+initrd" "${lk_args[@]}"
+	"${linuxkit_bin}" build "--format" "kernel+initrd" "${lk_debug_args[@]}" "${lk_args[@]}"
 
 	declare initramfs_path="${lk_output_dir}/hook-initrd.img"
 	# initramfs_path is a gzipped file. obtain the uncompressed byte size, without decompressing it

--- a/bash/shellcheck.sh
+++ b/bash/shellcheck.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 function download_prepare_shellcheck_bin() {
-	declare SHELLCHECK_VERSION=${SHELLCHECK_VERSION:-0.10.0} # https://github.com/koalaman/shellcheck/releases
-	log info "Downloading and preparing shellcheck binary for version v${SHELLCHECK_VERSION}..."
+	declare SHELLCHECK_VERSION=${SHELLCHECK_VERSION:-"0.10.0"} # https://github.com/koalaman/shellcheck/releases
+	log info "Preparing shellcheck binary for version v${SHELLCHECK_VERSION}..."
 
 	declare bash_machine="${BASH_VERSINFO[5]}"
 	declare shellcheck_os="" shellcheck_arch=""
@@ -49,6 +49,51 @@ function download_prepare_shellcheck_bin() {
 	return 0
 }
 
+# Same, but for shellfmt
+function download_prepare_shellfmt_bin() {
+	declare SHELLFMT_VERSION=${SHELLFMT_VERSION:-"3.10.0"} # https://github.com/mvdan/sh/releases/
+	log info "Preparing shellfmt binary for version v${SHELLFMT_VERSION}..."
+
+	declare bash_machine="${BASH_VERSINFO[5]}"
+	declare shellfmt_os="" shellfmt_arch=""
+	case "$bash_machine" in
+		*darwin*) shellfmt_os="darwin" ;;
+		*linux*) shellfmt_os="linux" ;;
+		*)
+			log error "unknown os: $bash_machine"
+			exit 3
+			;;
+	esac
+
+	case "$bash_machine" in
+		*aarch64*) shellfmt_arch="arm64" ;;
+		*x86_64*) shellfmt_arch="amd64" ;;
+		*)
+			log error "unknown arch: $bash_machine"
+			exit 2
+			;;
+	esac
+
+	declare shellfmt_fn="shfmt_v${SHELLFMT_VERSION}_${shellfmt_os}_${shellfmt_arch}"
+	declare DOWN_URL="https://github.com/mvdan/sh/releases/download/v${SHELLFMT_VERSION}/${shellfmt_fn}"
+	declare -g -r SHELLFMT_BIN="${CACHE_DIR}/${shellfmt_fn}"
+
+	if [[ ! -f "${SHELLFMT_BIN}" ]]; then
+		log info "Cache miss for shellfmt binary, downloading..."
+		log debug "bash_machine: ${bash_machine}"
+		log debug "Down URL: ${DOWN_URL}"
+		log debug "SHELLFMT_BIN: ${SHELLFMT_BIN}"
+		curl -sL "${DOWN_URL}" -o "${SHELLFMT_BIN}.tmp"
+		chmod +x "${SHELLFMT_BIN}.tmp"
+		mv "${SHELLFMT_BIN}.tmp" "${SHELLFMT_BIN}"
+	fi
+
+	declare -g SHELLFMT_ACTUAL_VERSION="unknown"
+	SHELLFMT_ACTUAL_VERSION="$("${SHELLFMT_BIN}" --version)"
+	declare -g -r SHELLFMT_ACTUAL_VERSION="${SHELLFMT_ACTUAL_VERSION}"
+	log debug "SHELLFMT_ACTUAL_VERSION: ${SHELLFMT_ACTUAL_VERSION}"
+}
+
 function run_shellcheck() {
 	declare -a params=() excludes=()
 
@@ -74,4 +119,27 @@ function run_shellcheck() {
 		log error "Shellcheck detected problems in bash code; check output above."
 		exit 1
 	fi
+}
+
+function run_shellfmt() {
+	log info "Running shellfmt ${SHELLFMT_ACTUAL_VERSION} against all bash files, please wait..."
+	declare -a all_bash_files=()
+	all_bash_files+=("build.sh")                                   # The root build script
+	mapfile -t all_bash_files < <(find bash/ -type f -name "*.sh") # All .sh under bash/
+	log debug "All bash files: ${all_bash_files[*]}"
+
+	# First, run shellfmt with --diff: it will exit with an error if changes are needed.
+	if ! "${SHELLFMT_BIN}" --diff "${all_bash_files[@]}"; then
+		log warn "Shellfmt detected deviations in bash code formatting."
+		log info "Re-running shellfmt with --write to fix the deviations..."
+		if ! "${SHELLFMT_BIN}" --write "${all_bash_files[@]}"; then
+			log error "Shellfmt failed to fix deviations in bash code formatting."
+			exit 66
+		else
+			log info "Shellfmt fixed deviations in bash code formatting."
+		fi
+		exit 1 # So CI breaks
+	fi
+	log info "Shellfmt detected no deviations in bash code formatting."
+	return 0
 }

--- a/build.sh
+++ b/build.sh
@@ -82,6 +82,20 @@ case "${first_param}" in
 		exit 0
 		;;
 
+	shellfmt)
+		download_prepare_shellfmt_bin
+		run_shellfmt # this exits with an error if changes are made
+		exit 0
+		;;
+
+	lint)
+		download_prepare_shellcheck_bin
+		download_prepare_shellfmt_bin
+		run_shellcheck
+		run_shellfmt # this exits with an error if changes are made
+		exit 0
+		;;
+
 	gha-matrix)
 		output_gha_matrixes
 		exit 0

--- a/build.sh
+++ b/build.sh
@@ -26,7 +26,7 @@ parse_command_line_arguments "${@}" # which fills the above vars & exports the k
 declare -g HOOK_KERNEL_OCI_BASE="${HOOK_KERNEL_OCI_BASE:-"quay.io/tinkerbell/hook-kernel"}"
 declare -g HOOK_LK_CONTAINERS_OCI_BASE="${HOOK_LK_CONTAINERS_OCI_BASE:-"quay.io/tinkerbell/"}"
 
-declare -g SKOPEO_IMAGE="${SKOPEO_IMAGE:-"quay.io/skopeo/stable:latest"}"
+declare -g SKOPEO_IMAGE="${SKOPEO_IMAGE:-"quay.io/skopeo/stable:v1.17.0"}" # See https://quay.io/repository/skopeo/stable?tab=tags&tag=latest
 
 # See https://github.com/linuxkit/linuxkit/releases
 declare -g -r LINUXKIT_VERSION_DEFAULT="1.5.3" # LinuxKit version to use by default; each flavor can set its own too

--- a/build.sh
+++ b/build.sh
@@ -29,7 +29,7 @@ declare -g HOOK_LK_CONTAINERS_OCI_BASE="${HOOK_LK_CONTAINERS_OCI_BASE:-"quay.io/
 declare -g SKOPEO_IMAGE="${SKOPEO_IMAGE:-"quay.io/skopeo/stable:latest"}"
 
 # See https://github.com/linuxkit/linuxkit/releases
-declare -g -r LINUXKIT_VERSION_DEFAULT="1.5.2" # LinuxKit version to use by default; each flavor can set its own too
+declare -g -r LINUXKIT_VERSION_DEFAULT="1.5.3" # LinuxKit version to use by default; each flavor can set its own too
 
 # Directory to use for storing downloaded artifacts: LinuxKit binary, shellcheck binary, etc.
 declare -g -r CACHE_DIR="${CACHE_DIR:-"cache"}"

--- a/images/hook-containerd/Dockerfile
+++ b/images/hook-containerd/Dockerfile
@@ -1,4 +1,4 @@
-FROM linuxkit/alpine:146f540f25cd92ec8ff0c5b0c98342a9a95e479e as builder
+FROM linuxkit/alpine:146f540f25cd92ec8ff0c5b0c98342a9a95e479e AS builder
 
 ARG TARGETPLATFORM
 
@@ -29,7 +29,7 @@ RUN cp bin/containerd bin/ctr bin/containerd-shim bin/containerd-shim-runc-v2 /u
 RUN strip /usr/bin/containerd /usr/bin/ctr /usr/bin/containerd-shim /usr/bin/containerd-shim-runc-v2
 RUN mkdir -p /opt/containerd
 
-FROM scratch as containerd-dev
+FROM scratch AS containerd-dev
 ENTRYPOINT []
 WORKDIR /
 COPY --from=builder /usr/bin/containerd /usr/bin/ctr /usr/bin/containerd-shim /usr/bin/containerd-shim-runc-v2 /usr/bin/
@@ -38,7 +38,7 @@ COPY --from=builder /usr/local/bin/nerdctl /usr/bin/
 COPY --from=builder /opt/containerd/ /opt/containerd/
 
 # Dockerfile to build linuxkit/containerd for linuxkit
-FROM linuxkit/alpine:146f540f25cd92ec8ff0c5b0c98342a9a95e479e as alpine
+FROM linuxkit/alpine:146f540f25cd92ec8ff0c5b0c98342a9a95e479e AS alpine
 
 RUN apk add tzdata binutils
 RUN mkdir -p /etc/init.d && ln -s /usr/bin/service /etc/init.d/020-containerd

--- a/images/hook-runc/Dockerfile
+++ b/images/hook-runc/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile to build linuxkit/runc for linuxkit
-FROM linuxkit/alpine:146f540f25cd92ec8ff0c5b0c98342a9a95e479e as alpine
+FROM linuxkit/alpine:146f540f25cd92ec8ff0c5b0c98342a9a95e479e AS alpine
 RUN \
   apk add \
   bash \

--- a/kernel/.dockerignore
+++ b/kernel/.dockerignore
@@ -3,3 +3,4 @@
 Dockerfile*
 Makefile
 README.md
+!Dockerfile.autogen.helper*

--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable as kernel-source-unpacked
+FROM debian:stable AS kernel-source-unpacked
 ENV DEBIAN_FRONTEND=noninteractive
 
 # crossbuild-essentials are pretty heavy; here we install for both architecures to maximize Docker layer hit cache rate during development, but only one will be used
@@ -30,7 +30,7 @@ RUN set -x &&  \
     cat linux-${KERNEL_VERSION}.tar | tar --absolute-names -x && mv /linux-${KERNEL_VERSION} /linux
 
 
-FROM kernel-source-unpacked as kernel-with-config
+FROM kernel-source-unpacked AS kernel-with-config
 
 ARG INPUT_DEFCONFIG
 ARG KERNEL_ARCH
@@ -54,7 +54,7 @@ RUN set -x && make "ARCH=${KERNEL_ARCH}" olddefconfig
 #   docker buildx build --load --progress=plain --build-arg KERNEL_VERSION=5.10.212 --build-arg KERNEL_SERIES=5.10.y -t hook-kernel:builder --target kernel-configurator .
 #   docker run -it -v "$(pwd)":/out-config hook-kernel:builder
 # Otherwise, since this stage is not referenced anywhere during normal build, it is completely skipped
-FROM kernel-with-config as kernel-configurator
+FROM kernel-with-config AS kernel-configurator
 VOLUME /host
 
 


### PR DESCRIPTION
> further enhancements:
> - can now build (and develop) Hook for any arch under any arch, including for amd64 under Darwin arm64
> - full support for building on macOS+brew, including on arm64
> - added `shellfmt` tool and bash code format enforcing on CI (in addition to shellcheck)
> - avoid pulling skopeo image over and over again

----

### build: implement `shellfmt` (and `lint` which does both shellcheck/fmt)

- for consistent bash formatting
- include an .editorconfig for IDE's

### gha: switch to `lint` (which does both `shellcheck` and `shellfmt`)

### linuxkit: bump 1.5.2 -> 1.5.3

### build: implement build-host dependency handling for macOS+brew

- if on macOS+brew:
  - detects missing deps and installs them with brew
  - exports PATH with brew-based GNU versions first
    - coreutils, gnu-sed and gnu-tar included

### build: Dockerfile: fix FROM xx AS casing

- to squash recent BuildKit warnings

### build: pass `--verbose 2` to linuxkit if `DEBUG=yes`

- can help with some edge cases

### build: refactor skopeo pull and list-tags functions

- this only affects Armbian kernel flavours
- avoids pulling if found in local cache

### build: use skopeo `v1.17.0` instead of latest

- since we now use the local tag

### build: armbian: kernel: refactor Dockerfile with helper

- building the Armbian kernels would produce different hashes depending on the arch of the host
- moving the affected code into the Dockerfile would lead to escaping pain; instead implement a docker.sh helper
- in practice, all code in the Dockerfile is hashed, but the arch decision is now therein and hash won't change
- also, allows for reuse, which is bound to come later

### build: docker: detect & export `DOCKER_HOST` from current `docker context`

- Some Docker-in-VM solutions (like Docker Desktop, colima, etc) set a non-default docker context pointing to the correct socket
- Seems LinuxKit fumbles detecting this and ends up silently failing all local-Docker-daemon cache hits
  - that is fine for CI, where all images are (beforehand) pushed to the registry (and thus LK ends up pulling from remote), but not during local development
  - reported to upstream LinuxKit: https://github.com/linuxkit/linuxkit/issues/4092

### build: kernel: force target arch on cross-built kernel docker image manifest

- our kernel builds are done in arch-independent Dockerfiles
- but those get the build-host's architecture, despite the contents being correct
- when locally developing on a kernel that is != host-arch
  - those get the host-arch in the image
  - but LinuxKit refuses to use it due to arch mismatch
- (when pushed to a registry, the arch info is discarded, and LK is ok with that)
- thus
  - introduce `ensure_docker_image_architecture(imagetag, arch)`
    - which just hacks at manifests via a docker save/docker load
  - call it from both default and armbian kernel builds

### build: docker: avoid Docker Inc's "What's next" hints

- enough spam already, thanks

-----

Signed-off-by: Ricardo Pardini <ricardo@pardini.net>