### PR TITLE
Hook `bootable` media for amd64/arm64 UEFI + RPi 3/4/5 + Rockchip/Amlogic u-boot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ hook*.*.yaml
 !linuxkit-templates
 out/
 cache/
+bootable/
+!bash/bootable
 *.swp
 .idea
 kernel/Dockerfile.autogen.*

--- a/bash/bootable-media.sh
+++ b/bash/bootable-media.sh
@@ -12,8 +12,11 @@ function build_bootable_media() {
 
 	# Get the kernel info from the bootable_info INVENTORY_ID
 	declare -g -A kernel_info=()
-	get_kernel_info_dict "${bootable_info['INVENTORY_ID']}"
+	declare -g inventory_id="${bootable_info['INVENTORY_ID']}"
+	get_kernel_info_dict "${inventory_id}"
 	log info "kernel_info: $(declare -p kernel_info)"
+	set_kernel_vars_from_info_dict
+	kernel_obtain_output_id # sets OUTPUT_ID
 
 	# A few scenarios we want to support:
 	# A) UEFI bootable media; GPT + ESP, FAT32, GRUB, kernel/initrd, grub.conf + some kernel command line.

--- a/bash/bootable-media.sh
+++ b/bash/bootable-media.sh
@@ -2,7 +2,6 @@ function build_bootable_media() {
 	log info "would build build_bootable_media: '${*}'"
 
 	declare -r -g bootable_id="${1}" # read-only variable from here
-	#obtain_bootable_data_from_id "${bootable_id}" # Gather the information about the inventory_id now; this will exit if the inventory_id is not found
 
 	declare -g -A bootable_info=()
 	get_bootable_info_dict "${bootable_id}"

--- a/bash/bootable-media.sh
+++ b/bash/bootable-media.sh
@@ -1,0 +1,63 @@
+function build_bootable_media() {
+	log info "would build build_bootable_media: '${*}'"
+
+	declare -r -g bootable_id="${1}" # read-only variable from here
+	#obtain_bootable_data_from_id "${bootable_id}" # Gather the information about the inventory_id now; this will exit if the inventory_id is not found
+
+	declare -g -A bootable_info=()
+	get_bootable_info_dict "${bootable_id}"
+
+	# Dump the bootable_info dict
+	log info "bootable_info: $(declare -p bootable_info)"
+
+	# Get the kernel info from the bootable_info INVENTORY_ID
+	declare -g -A kernel_info=()
+	get_kernel_info_dict "${bootable_info['INVENTORY_ID']}"
+	log info "kernel_info: $(declare -p kernel_info)"
+
+	# A few scenarios we want to support:
+	# A) UEFI bootable media; GPT + ESP, FAT32, GRUB, kernel/initrd, grub.conf + some kernel command line.
+	# B) RPi 3b/4/5 bootable media; GPT, non-ESP partition, FAT32, kernel/initrd, config.txt, cmdline.txt + some kernel command line.
+	# C) Rockchip bootable media; GPT, non-ESP partition, FAT32, extlinux.conf + some kernel command line; write u-boot bin on top of GPT via Armbian sh
+	# D) Amlogic bootable media; MBR, FAT32, extlinux.conf + some kernel command line; write u-boot bin on top of MBR via Armbian sh
+
+	# General process:
+	# Obtain extra variables from environment (BOARD/BRANCH for armbian); optional.
+	# Obtain the latest Armbian u-boot version from the OCI registry, using Skopeo.
+	# 1) (C/D) Obtain the u-boot artifact binaries using ORAS, given the version above; massage using Docker and extract the binaries.
+	# 1) (A) Obtain grub somehow; LinuxKit has them ready-to-go in a Docker image.
+	# 1) (B) Obtain the rpi firmware files (bootcode.bin, start.elf, fixup.dat) from the RaspberryPi Foundation
+	# 2) Prepare the FAT32 contents; kernel/initrd, grub.conf, config.txt, cmdline.txt, extlinux.conf depending on scenario
+	# 3) Create a GPT+ESP, GTP+non-ESP, or MBR partition table image with the contents of the FAT32 (use libguestfs)
+	# 4) For the scenarios with u-boot, write u-boot binaries to the correct offsets in the image.
+
+	# @TODO: possibly make sure the kernel and lk is built before delegating?
+
+	# Call the bootable build function
+	declare bootable_build_func="${bootable_info['BOOTABLE_BUILD_FUNC']}"
+	log info "Calling bootable build function: ${bootable_build_func}"
+	"${bootable_build_func}"
+
+}
+
+function get_bootable_info_dict() {
+	declare bootable="${1}"
+	declare bootable_data_str="${bootable_inventory_dict[${bootable}]}"
+	if [[ -z "${bootable_data_str}" ]]; then
+		log error "No bootable data found for '${bootable}'; valid ones are: ${bootable_inventory_ids[*]} "
+		exit 1
+	fi
+	log debug "Bootable data for '${bootable}': ${bootable_data_str}"
+	declare -g -A bootable_info
+	eval "bootable_info=(${bootable_data_str})"
+
+	# Post process; calculate bash function names given the handler
+	bootable_info['BOOTABLE_LIST_FUNC']="list_bootable_${bootable_info['HANDLER']}"
+	bootable_info['BOOTABLE_BUILD_FUNC']="build_bootable_${bootable_info['HANDLER']}"
+
+	# Ensure bootable_info a valid TAG
+	if [[ -z "${bootable_info['TAG']}" ]]; then
+		log error "No TAG found for bootable '${bootable}'"
+		exit 1
+	fi
+}

--- a/bash/bootable/armbian-u-boot.sh
+++ b/bash/bootable/armbian-u-boot.sh
@@ -1,0 +1,321 @@
+# A few scenarios we want to support:
+# A) UEFI bootable media; GPT + ESP, FAT32, GRUB, kernel/initrd, grub.conf + some kernel command line.
+# B) RPi 3b/4/5 bootable media; GPT, non-ESP partition, FAT32, kernel/initrd, config.txt, cmdline.txt + some kernel command line.
+# C) Rockchip bootable media; GPT, non-ESP partition, FAT32, extlinux.conf + some kernel command line; write u-boot bin on top of GPT via Armbian sh
+# D) Amlogic bootable media; MBR, FAT32, extlinux.conf + some kernel command line; write u-boot bin on top of MBR via Armbian sh
+
+# General process:
+# Obtain extra variables from environment (BOARD/BRANCH for armbian); optional.
+# Obtain the latest Armbian u-boot version from the OCI registry, using Skopeo.
+# 1) (C/D) Obtain the u-boot artifact binaries using ORAS, given the version above; massage using Docker and extract the binaries.
+# 1) (A) Obtain grub somehow; LinuxKit has them ready-to-go in a Docker image.
+# 1) (B) Obtain the rpi firmware files (bootcode.bin, start.elf, fixup.dat) from the RaspberryPi Foundation
+# 2) Prepare the FAT32 contents; kernel/initrd, grub.conf, config.txt, cmdline.txt, extlinux.conf depending on scenario
+# 3) Create a GPT+ESP, GTP+non-ESP, or MBR partition table image with the contents of the FAT32 (use mtools)
+# 4) For the scenarios with u-boot, write u-boot binaries to the correct offsets in the image.
+
+function list_bootable_armbian_uboot_amlogic() {
+	declare -g -A bootable_boards=()
+	bootable_boards["odroidhc4"]="BOARD=odroidhc4 BRANCH=edge"
+	bootable_boards["khadas-vim3"]="BOARD=khadas-vim3 BRANCH=edge"
+}
+
+function build_bootable_armbian_uboot_amlogic() {
+	declare partition_type="msdos" # amlogic boot media must be MBR, as u-boot offsets conflict with GPT
+	build_bootable_armbian_uboot
+}
+
+function list_bootable_armbian_uboot_rockchip() {
+	declare -g -A bootable_boards=()
+	bootable_boards["odroidm1"]="BOARD=odroidm1 BRANCH=edge"
+	bootable_boards["rockpro64"]="BOARD=rockpro64 BRANCH=edge"
+	bootable_boards["nanopct6"]="BOARD=nanopct6 BRANCH=edge"
+	bootable_boards["cm3588-nas"]="BOARD=cm3588-nas BRANCH=edge"
+}
+
+function build_bootable_armbian_uboot_rockchip() {
+	build_bootable_armbian_uboot
+}
+
+function list_bootable_armbian_uboot_rockchip_vendor() {
+	declare -g -A bootable_boards=()
+	bootable_boards["r58x"]="BOARD=mekotronics-r58x-pro BRANCH=vendor"
+}
+
+function build_bootable_armbian_uboot_rockchip_vendor() {
+	build_bootable_armbian_uboot
+}
+
+function build_bootable_armbian_uboot() {
+	: "${bootable_info['INVENTORY_ID']:?"bootable_info['INVENTORY_ID'] is unset"}"
+
+	declare hook_id="${bootable_info['INVENTORY_ID']}"
+	# UBOOT_TYPE can be either extlinux or bootscript; defaults to bootscript
+	declare uboot_type="${bootable_info['UBOOT_TYPE']:-"bootscript"}"
+
+	declare -A hook_files=(
+		["kernel"]="vmlinuz-${hook_id}"
+		["initrd"]="initramfs-${hook_id}"
+		["dtbs"]="dtbs-${hook_id}.tar.gz"
+	)
+
+	# Check if all the required files are present; if not, give instructions on how to build kernel and hook $hook_id
+	for file in "${!hook_files[@]}"; do
+		if [[ ! -f "out/hook/${hook_files[$file]}" ]]; then
+			log error "Required file 'out/hook/${hook_files[$file]}' not found; please build the kernel and hook ${hook_id} first: ./build.sh kernel ${hook_id} && ./build.sh build ${hook_id}"
+			exit 1
+		fi
+	done
+
+	log info "Building Armbian u-boot for hook ${hook_id} with type ${uboot_type}"
+
+	# if BOARD is unset, bail
+	if [[ -z "${BOARD}" ]]; then
+		log error "BOARD is unset; please pass BOARD=xxx in the command line or env-var"
+		exit 2
+	fi
+
+	# if BRANCH is unset, bail
+	if [[ -z "${BRANCH}" ]]; then
+		log error "BRANCH is unset; please pass BRANCH=xxx in the command line or env-var"
+		exit 2
+	fi
+
+	# Prepare the base working directory in bootable/
+	declare bootable_dir="armbian-uboot-${BOARD}-${BRANCH}"
+	declare bootable_base_dir="bootable/${bootable_dir}"
+	rm -rf "${bootable_base_dir}"
+	mkdir -p "${bootable_base_dir}"
+
+	declare uboot_oci_package_name="uboot-${BOARD}-${BRANCH}"
+	log info "Using Armbian u-boot package: '${uboot_oci_package_name}'"
+
+	declare output_uboot_tarball="${bootable_base_dir}/uboot.tar.gz"
+
+	obtain_armbian_uboot_tar_gz_from_oci # takes uboot_oci_package_name, BOARD, BRANCH, UBOOT_VERSION, ARMBIAN_BASE_ORAS_REF and output_uboot_tarball
+
+	# Extract the tarball so we can get at the metadata files inside
+	declare uboot_extract_dir="${bootable_base_dir}/uboot-files"
+	mkdir -p "${uboot_extract_dir}"
+	tar -C "${uboot_extract_dir}" --strip-components=1 -xzf "${output_uboot_tarball}"
+
+	# Source the platform_install.sh (defines function write_uboot_platform <uboot-bin-dir> <output-device-or-file>)
+	declare platform_install_sh="${uboot_extract_dir}/platform_install.sh"
+	# shellcheck disable=SC1090
+	source "${platform_install_sh}"
+
+	# Source the metadata.sh file; declares UBOOT_PARTITION_TYPE, UBOOT_KERNEL_DTB, UBOOT_KERNEL_SERIALCON, UBOOT_EXTLINUX_PREFER, UBOOT_EXTLINUX_CMDLINE
+	declare metadata_sh="${uboot_extract_dir}/u-boot-metadata.sh"
+	# shellcheck disable=SC1090
+	source "${metadata_sh}"
+
+	log info "u-boot UBOOT_PARTITION_TYPE: ${UBOOT_PARTITION_TYPE}"
+	log info "u-boot UBOOT_KERNEL_DTB: ${UBOOT_KERNEL_DTB}"
+	log info "u-boot UBOOT_KERNEL_SERIALCON: ${UBOOT_KERNEL_SERIALCON}"
+	log info "u-boot UBOOT_EXTLINUX_PREFER: ${UBOOT_EXTLINUX_PREFER}"
+	log info "u-boot UBOOT_EXTLINUX_CMDLINE: ${UBOOT_EXTLINUX_CMDLINE}"
+	log info "u-boot uboot_type: ${uboot_type}"
+
+	# Prepare a directory that will be the root of the FAT32 partition
+	declare fat32_root_dir="${bootable_base_dir}/fat32-root"
+	mkdir -p "${fat32_root_dir}"
+
+	# Kernel and initrd go directly in the root of the FAT32 partition
+	cp -vp "out/hook/vmlinuz-${hook_id}" "${fat32_root_dir}/vmlinuz"
+	cp -vp "out/hook/initramfs-${hook_id}" "${fat32_root_dir}/initramfs"
+
+	declare -i initramfs_size_bytes
+	initramfs_size_bytes=$(stat --format="%s" "${fat32_root_dir}/initramfs")
+
+	# DTBs go into a dtb subdirectory
+	mkdir -p "${fat32_root_dir}/dtb"
+	# Extract the DTB .tar.gz into the root of the FAT32 partition; skip the first directory of the path of the extracted files
+	tar -C "${fat32_root_dir}/dtb" --strip-components=1 -xzf "out/hook/dtbs-${hook_id}.tar.gz"
+	# Get rid of any directories named 'overlays' in the DTB directory?
+	# find "${fat32_root_dir}/dtb" -type d -name 'overlays' -exec rm -rf {} \;
+
+	# Prepare an extlinux.conf or boot.scr file with the kernel command line; this is board-specific
+	# it also might require the metadata files from the uboot tarball, as those have details eg the exact DTB to use, console information, etc.
+	write_uboot_script_or_extlinux "${fat32_root_dir}"
+
+	# Show the state
+	du -h -d 1 "${bootable_base_dir}"
+
+	# Use a Dockerfile to assemble a GPT image, with a single FAT32 partition, containing the files in the fat32-root directory
+	# This is common across all GPT-based bootable media; the only difference is the ESP flag, which is set for UEFI bootable media but not for Rockchip/RaspberryPi
+	# The u-boot binaries are written _later_ in the process, after the image is created, using Armbian's helper scripts.
+	create_image_fat32_root_from_dir "${bootable_base_dir}" "bootable-media-${BOARD}-${BRANCH}.img" "${bootable_dir}/fat32-root"
+
+	log info "Show info about produced image..."
+	ls -lah "${bootable_base_dir}/bootable-media-${BOARD}-${BRANCH}.img"
+
+	# Deploy u-boot binaries to the image; use the function defined in the platform_install.sh script
+	# They should only use 'dd' or such; we've special handling for dd, to add 'conv=trunc'
+
+	# shellcheck disable=SC2317 # used by write_uboot_platform
+	function dd() {
+		# We're going to use dd to write the u-boot binaries to the image; log the command and then run it
+		log info "dd: ${1} + conv=notrunc"
+		log debug "dd: ${*@Q}"
+		command dd "$@" "conv=notrunc"
+	}
+
+	log info "Writing u-boot binaries to the image..."
+	write_uboot_platform "${uboot_extract_dir}" "${bootable_base_dir}/bootable-media-${BOARD}-${BRANCH}.img"
+
+	log info "Show info about produced image (with written u-boot)..."
+	ls -lah "${bootable_base_dir}/bootable-media-${BOARD}-${BRANCH}.img"
+
+	log info "Done building Armbian u-boot for hook ${hook_id} with type ${uboot_type}"
+	output_bootable_media "${bootable_base_dir}/bootable-media-${BOARD}-${BRANCH}.img" "hook-bootable-${BOARD}-${BRANCH}.img"
+
+	return 0
+}
+
+function write_uboot_script_or_extlinux() {
+	# choose with a case based on uboot_type
+	case "${uboot_type}" in
+		"extlinux")
+			log info "Writing extlinux.conf..."
+			write_uboot_extlinux "${@}"
+			;;
+
+		"bootscript")
+			log info "Writing boot.scr..."
+			write_uboot_script "${@}"
+			;;
+
+		*)
+			log error "Unknown uboot_type: ${uboot_type}"
+			exit 1
+			;;
+	esac
+}
+
+function write_uboot_script() {
+	declare fat32_root_dir="${1}"
+	declare boot_cmd_file="${fat32_root_dir}/boot.cmd"
+	cat <<- BOOT_CMD > "${boot_cmd_file}"
+		# Hook u-boot bootscript; mkimage -C none -A arm -T script -d /boot.cmd /boot.scr
+		echo "Starting Tinkerbell Hook boot script..."
+		printenv
+		setenv kernel_addr_r "0x20000000"
+		setenv ramdisk_addr_r "0x40000000"
+		test -n "\${distro_bootpart}" || distro_bootpart=1
+		echo "Boot script loaded from \${devtype} \${devnum}:\${distro_bootpart}"
+		setenv bootargs "${UBOOT_EXTLINUX_CMDLINE}"
+		echo "Booting with: \${bootargs}"
+
+		echo "Loading initramfs... \${ramdisk_addr_r} /uinitrd"
+		load \${devtype} \${devnum}:\${distro_bootpart} \${ramdisk_addr_r} /uinitrd
+		echo "Loading kernel... \${kernel_addr_r} /vmlinuz"
+		load \${devtype} \${devnum}:\${distro_bootpart} \${kernel_addr_r} /vmlinuz
+		echo "Loading dtb... \${fdt_addr_r} /dtb/${UBOOT_KERNEL_DTB}"
+		load \${devtype} \${devnum}:\${distro_bootpart} \${fdt_addr_r} /dtb/${UBOOT_KERNEL_DTB}
+
+		fdt addr \${fdt_addr_r}
+		fdt resize 65536
+
+		echo "Booting: booti \${kernel_addr_r} \${ramdisk_addr_r} \${fdt_addr_r} - args: \${bootargs}"
+		booti \${kernel_addr_r} \${ramdisk_addr_r} \${fdt_addr_r}
+	BOOT_CMD
+
+	command -v bat &> /dev/null && bat --file-name "boot.scr" "${boot_cmd_file}"
+
+	return 0
+}
+
+function write_uboot_extlinux() {
+	declare fat32_root_dir="${1}"
+
+	declare console_extra_args="${bootable_info['CONSOLE_EXTRA_ARGS']:-""}"
+	declare bootargs="${UBOOT_EXTLINUX_CMDLINE} console=${UBOOT_KERNEL_SERIALCON}${console_extra_args}"
+	log info "Writing extlinux.conf; kernel cmdline: ${bootargs}"
+
+	mkdir -p "${fat32_root_dir}/extlinux"
+	declare extlinux_conf="${fat32_root_dir}/extlinux/extlinux.conf"
+	cat <<- EXTLINUX_CONF > "${extlinux_conf}"
+		DEFAULT hook
+		LABEL hook
+			linux /vmlinuz
+			initrd /initramfs
+			append ${bootargs}
+			fdt /dtb/${UBOOT_KERNEL_DTB}
+	EXTLINUX_CONF
+	# @TODO: fdtdir when UBOOT_KERNEL_DTB is unset
+
+	command -v bat && bat --file-name "extlinux.conf" "${extlinux_conf}"
+
+	return 0
+}
+
+function obtain_armbian_uboot_tar_gz_from_oci() {
+
+	declare uboot_oci_package="${ARMBIAN_BASE_ORAS_REF}/${uboot_oci_package_name}"
+	log info "Using Armbian u-boot OCI package: '${uboot_oci_package}'"
+
+	# if UBOOT_VERSION is set, use it; otherwise obtain the latest one from the OCI registry via Skopeo
+	if [[ -z "${UBOOT_VERSION}" ]]; then
+		log info "UBOOT_VERSION is unset, obtaining the most recently pushed-to tag of ${uboot_oci_package}"
+		declare latest_tag_for_docker_image
+		get_latest_tag_for_docker_image_using_skopeo "${uboot_oci_package}" ".\-S..." # regex to match the tag, like "2017.09-Sxxxx"
+		UBOOT_VERSION="${latest_tag_for_docker_image}"
+		log info "Using most recent Armbian u-boot tag: ${UBOOT_VERSION}"
+	fi
+
+	declare uboot_oci_ref="${uboot_oci_package}:${UBOOT_VERSION}"
+	log info "Using Armbian u-boot OCI ref: '${uboot_oci_ref}'"
+
+	# Obtain the relevant u-boot files from the Armbian OCI artifact; use a Dockerfile+ image + extraction to do so.
+	# The armbian-uboot is a .deb package inside an OCI artifact.
+	# A helper script, as escaping bash into a RUN command in Dockerfile is a pain; included in input_hash later
+	mkdir -p "bootable"
+	declare dockerfile_helper_filename="undefined.sh"
+	produce_dockerfile_helper_apt_oras "bootable/" # will create the helper script in bootable/ directory; sets helper_name
+
+	# Lets create a Dockerfile that will be used to obtain the artifacts needed, using ORAS binary
+	declare -g armbian_uboot_extract_dockerfile="bootable/Dockerfile.autogen.armbian.uboot-${BOARD}-${BRANCH}-${UBOOT_VERSION}"
+	log info "Creating Dockerfile '${armbian_uboot_extract_dockerfile}'... "
+	cat <<- ARMBIAN_ORAS_UBOOT_DOCKERFILE > "${armbian_uboot_extract_dockerfile}"
+		FROM debian:stable AS downloader
+		# Call the helper to install curl, oras
+		ADD ./${dockerfile_helper_filename} /apt-oras-helper.sh
+		RUN bash /apt-oras-helper.sh
+		FROM downloader AS downloaded
+		WORKDIR /armbian/uboot
+		WORKDIR /armbian/deb
+		RUN oras pull "${uboot_oci_ref}"
+		RUN dpkg-deb --extract linux-u-boot-*.deb /armbian/uboot
+		WORKDIR /armbian/uboot
+		WORKDIR /armbian/output/uboot-${BOARD}-${BRANCH}
+		RUN cp -vp /armbian/uboot/usr/lib/linux-u-boot-*/* .
+		RUN cp -vp /armbian/uboot/usr/lib/u-boot/platform_install.sh .
+		WORKDIR /armbian/output
+		RUN tar -czf uboot-${BOARD}-${BRANCH}.tar.gz uboot-${BOARD}-${BRANCH}
+		RUN rm -rf uboot-${BOARD}-${BRANCH}
+		FROM scratch
+		COPY --from=downloaded /armbian/output/* /
+	ARMBIAN_ORAS_UBOOT_DOCKERFILE
+
+	declare input_hash="" short_input_hash=""
+	input_hash="$(cat "${armbian_uboot_extract_dockerfile}" "bootable/${dockerfile_helper_filename}" | sha256sum - | cut -d ' ' -f 1)"
+	short_input_hash="${input_hash:0:8}"
+	log debug "Input hash for u-boot: ${input_hash}"
+	log debug "Short input hash for u-boot: ${short_input_hash}"
+
+	# Calculate the local image name for the u-boot extraction
+	declare uboot_oci_image="${HOOK_KERNEL_OCI_BASE}-armbian-uboot:${short_input_hash}"
+	log debug "Using local image name for u-boot extraction: '${uboot_oci_image}'"
+
+	# Now, build the Dockerfile...
+	log info "Building Dockerfile for u-boot extraction..."
+	docker buildx build --load "--progress=${DOCKER_BUILDX_PROGRESS_TYPE}" -t "${uboot_oci_image}" -f "${armbian_uboot_extract_dockerfile}" bootable
+
+	# Now get at the binaries inside the built image
+	log info "Extracting u-boot binaries from built Dockerfile... wait..."
+	docker create --name "export-uboot-${input_hash}" "${uboot_oci_image}" "command_is_irrelevant_here_container_is_never_started"
+	(docker export "export-uboot-${input_hash}" | tar -xO "uboot-${BOARD}-${BRANCH}.tar.gz" > "${output_uboot_tarball}") || true # don't fail -- otherwise container is left behind forever
+	docker rm "export-uboot-${input_hash}"
+	log info "Extracted u-boot binaries to '${output_uboot_tarball}'"
+
+}

--- a/bash/bootable/fat32-image.sh
+++ b/bash/bootable/fat32-image.sh
@@ -1,0 +1,94 @@
+function create_image_fat32_root_from_dir() {
+	declare output_dir="${1}"
+	declare output_filename="${2}"
+	declare fat32_root_dir="${3}"
+	declare partition_type="${partition_type:-"gpt"}"  # or, "msdos"
+	declare esp_partitition="${esp_partitition:-"no"}" # or, "yes" -- only for GPT; mark the fat32 partition as an ESP or not
+	declare output_image="${output_dir}/${output_filename}"
+
+	# Show whats about to be done
+	log info "Creating FAT32 image '${output_image}' from '${fat32_root_dir}'..."
+	log info "Partition type: ${partition_type}; ESP partition: ${esp_partitition}"
+
+	# Create a Dockerfile; install parted and mtools
+	mkdir -p "bootable"
+	declare dockerfile_helper_filename="undefined.sh"
+	produce_dockerfile_helper_apt_oras "bootable/" # will create the helper script in bootable/ directory; sets helper_name
+
+	# Lets create a Dockerfile that will be used to create the FAT32 image
+	cat <<- MKFAT32_SCRIPT > "bootable/Dockerfile.autogen.helper.mkfat32.sh"
+		#!/bin/bash
+		set -e
+		set -x
+
+		# Hack: transform the initramfs using mkimage to a u-boot image # @TODO refactor this out of here
+		if [ -f /work/input/initramfs ]]; then
+			mkimage -A arm64 -O linux -T ramdisk -C gzip -n uInitrd -d /work/input/initramfs /work/input/uinitrd
+			#rm -f /work/input/initramfs
+			ls -lah /work/input/uinitrd
+		fi
+
+		# Hack: boot.cmd -> boot.scr
+		if [ -f /work/input/boot.cmd ]; then
+			echo "Converting boot.cmd to boot.scr..."
+			mkimage -C none -A arm -T script -d /work/input/boot.cmd /work/input/boot.scr
+		fi
+
+		# Calculate the size of the image
+		# a) take the size, in megabytes, of /work/input directory
+		# b) add 32mb to it, 16 for the offset and 16 for extra files user might wanna put there
+		declare -i size_mb
+		size_mb="\$(du -s -BM /work/input | cut -f 1 | tr -d 'M')"
+		size_mb="\$((size_mb + 32))"
+		echo "Size of the image: \${size_mb}M" 1>&2
+
+		truncate -s \${size_mb}M /output/fat32.img
+		parted /output/fat32.img mklabel ${partition_type}
+		parted -a optimal /output/fat32.img mkpart primary fat32 16MiB 100%
+		if [ "${partition_type}" == "gpt" ] && [ "${esp_partitition}" == "yes" ]; then
+			parted /output/fat32.img set 1 esp on;
+		fi
+		mformat -i /output/fat32.img@@16M -F -v HOOK ::
+		mcopy -i /output/fat32.img@@16M -s /work/input/* ::
+		# list all the files in the fat32.img
+		mdir -i /output/fat32.img@@16M -s
+
+		parted /output/fat32.img print
+		if [ "${partition_type}" == "gpt" ]; then
+			sgdisk --print /output/fat32.img
+			sgdisk --info=1 /output/fat32.img
+		fi
+
+		mv -v /output/fat32.img /output/${output_filename}
+	MKFAT32_SCRIPT
+
+	# Lets create a Dockerfile that will be used to obtain the artifacts needed, using ORAS binary
+	declare -g mkfat32_dockerfile="bootable/Dockerfile.autogen.mkfat32"
+	log info "Creating Dockerfile '${mkfat32_dockerfile}'... "
+	cat <<- MKFAT32_DOCKERFILE > "${mkfat32_dockerfile}"
+		FROM debian:stable AS builder
+		# Call the helper to install curl, oras, parted, and mtools
+		ADD ./${dockerfile_helper_filename} /apt-oras-helper.sh
+		RUN bash /apt-oras-helper.sh parted mtools tree u-boot-tools gdisk
+		ADD ./${fat32_root_dir} /work/input
+		ADD ./Dockerfile.autogen.helper.mkfat32.sh /Dockerfile.autogen.helper.mkfat32.sh
+		WORKDIR /output
+		RUN bash /Dockerfile.autogen.helper.mkfat32.sh
+		FROM scratch
+		COPY --from=builder /output/* /
+	MKFAT32_DOCKERFILE
+
+	# Now, build the Dockerfile and output the fat32 image directly
+	log info "Building Dockerfile for fat32 image and outputting directly to '${output_image}'..."
+	docker buildx build --output "type=local,dest=${output_dir}" "--progress=${DOCKER_BUILDX_PROGRESS_TYPE}" -f "${mkfat32_dockerfile}" bootable
+
+	# Ensure the output image is named correctly; grab its size
+	if [ -f "${output_image}" ]; then
+		declare fat32img_size
+		fat32img_size="$(du -h "${output_image}" | cut -f 1)"
+		log info "Built fat32 image '${output_image}' (${fat32img_size})"
+	else
+		log error "Failed to build fat32 image, missing '${output_image}'"
+		exit 1
+	fi
+}

--- a/bash/bootable/fat32-image.sh
+++ b/bash/bootable/fat32-image.sh
@@ -69,7 +69,7 @@ function create_image_fat32_root_from_dir() {
 		FROM debian:stable AS builder
 		# Call the helper to install curl, oras, parted, and mtools
 		ADD ./${dockerfile_helper_filename} /apt-oras-helper.sh
-		RUN bash /apt-oras-helper.sh parted mtools tree u-boot-tools gdisk
+		RUN bash /apt-oras-helper.sh parted mtools u-boot-tools gdisk
 		ADD ./${fat32_root_dir} /work/input
 		ADD ./Dockerfile.autogen.helper.mkfat32.sh /Dockerfile.autogen.helper.mkfat32.sh
 		WORKDIR /output

--- a/bash/bootable/grub.sh
+++ b/bash/bootable/grub.sh
@@ -6,11 +6,13 @@ function list_bootable_grub() {
 }
 
 function build_bootable_grub() {
+	: "${kernel_info['DOCKER_ARCH']:?"kernel_info['DOCKER_ARCH'] is unset"}"
 	: "${bootable_info['INVENTORY_ID']:?"bootable_info['INVENTORY_ID'] is unset"}"
 	: "${OUTPUT_ID:?"OUTPUT_ID is unset"}"
 
 	declare hook_id="${bootable_info['INVENTORY_ID']}"
 	declare bootable_img="bootable_grub_${OUTPUT_ID}.img"
+	declare kernel_command_line="" # @TODO: common stuff for tink, etc
 
 	declare has_dtbs="${bootable_info['DTB']}"
 	[[ -z "${has_dtbs}" ]] && has_dtbs="no"
@@ -52,11 +54,15 @@ function build_bootable_grub() {
 	if [[ "${has_dtbs}" == "yes" ]]; then
 		mkdir -p "${fat32_root_dir}/dtb"
 		tar -C "${fat32_root_dir}/dtb" --strip-components=1 -xzf "out/hook/${hook_files["dtbs"]}"
-		tree "${fat32_root_dir}"
 	fi
 
-	### @TODO: obtain and write grub binary to EFI directory
-	### @TODO: write grub.cfg
+	# Grab the GRUB binaries from the LinuxKit Docker images
+	declare grub_arch="${kernel_info['DOCKER_ARCH']}"
+	declare grub_linuxkit_image="linuxkit/grub-dev:4184bd7644a0edf73d4fe8a55171fe06f4b4d738" # See https://github.com/linuxkit/linuxkit/blob/master/tools/grub/Dockerfile for the latest
+	declare fat32_efi_dir="${fat32_root_dir}/EFI/BOOT"
+	mkdir -p "${fat32_efi_dir}"
+
+	download_grub_binaries_from_linuxkit_docker_images "${fat32_efi_dir}" "${grub_arch}" "${grub_linuxkit_image}"
 
 	# Show the state
 	du -h -d 1 "${bootable_base_dir}"
@@ -74,5 +80,28 @@ function build_bootable_grub() {
 	output_bootable_media "${bootable_base_dir}/${bootable_img}" "hook-bootable-grub-${OUTPUT_ID}.img"
 
 	return 0
+}
 
+function download_grub_binaries_from_linuxkit_docker_images() {
+	declare output_dir="${1}"
+	declare arch="${2}"
+	declare image="${3}"
+	log info "Grabbing GRUB bins for arch '${arch}' from image '${image}'..."
+
+	# Lets create a Dockerfile that will be used to obtain the artifacts needed
+	declare -g grub_grabber_dockerfile="bootable/Dockerfile.autogen.grub_grabber"
+	log info "Creating Dockerfile '${grub_grabber_dockerfile}'... "
+
+	cat <<- GRUB_GRABBER_DOCKERFILE > "${grub_grabber_dockerfile}"
+		FROM --platform=linux/${arch} ${image} AS grub-build-${arch}
+		FROM scratch
+		COPY --from=grub-build-${arch} /*.EFI /
+	GRUB_GRABBER_DOCKERFILE
+
+	# Now, build the Dockerfile and output the fat32 image directly
+	log info "Building Dockerfile for GRUB grabber and outputting directly to '${output_dir}'..."
+	docker buildx build --output "type=local,dest=${output_dir}" "--progress=${DOCKER_BUILDX_PROGRESS_TYPE}" -f "${grub_grabber_dockerfile}" bootable
+
+	log info "Done, GRUB binaries are in ${output_dir}"
+	tree "${output_dir}"
 }

--- a/bash/bootable/grub.sh
+++ b/bash/bootable/grub.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+function list_bootable_grub() {
+	declare -g -A bootable_boards=()
+	bootable_boards["generic"]="NOT=used" # A single, generic "board" for all grub bootables
+}
+
+function build_bootable_grub() {
+	: "${bootable_info['INVENTORY_ID']:?"bootable_info['INVENTORY_ID'] is unset"}"
+	: "${OUTPUT_ID:?"OUTPUT_ID is unset"}"
+
+	declare hook_id="${bootable_info['INVENTORY_ID']}"
+	declare bootable_img="bootable_grub_${OUTPUT_ID}.img"
+
+	declare has_dtbs="${bootable_info['DTB']}"
+	[[ -z "${has_dtbs}" ]] && has_dtbs="no"
+
+	declare -A hook_files=(
+		["kernel"]="vmlinuz-${OUTPUT_ID}"
+		["initrd"]="initramfs-${OUTPUT_ID}"
+	)
+
+	if [[ "${has_dtbs}" == "yes" ]]; then
+		hook_files["dtbs"]="dtbs-${OUTPUT_ID}.tar.gz"
+	fi
+
+	# Check if all the required files are present; if not, give instructions on how to build kernel and hook $hook_id
+	for file in "${!hook_files[@]}"; do
+		if [[ ! -f "out/hook/${hook_files[$file]}" ]]; then
+			log error "Required file 'out/hook/${hook_files[$file]}' not found; please build the kernel and hook ${hook_id} first: ./build.sh kernel ${hook_id} && ./build.sh build ${hook_id}"
+			exit 1
+		fi
+	done
+
+	log info "Building grub bootable for hook ${hook_id}"
+
+	# Prepare the base working directory in bootable/
+	declare bootable_dir="grub"
+	declare bootable_base_dir="bootable/${bootable_dir}"
+	rm -rf "${bootable_base_dir}"
+	mkdir -p "${bootable_base_dir}"
+
+	# Prepare a directory that will be the root of the FAT32 partition
+	declare fat32_root_dir="${bootable_base_dir}/fat32-root"
+	mkdir -p "${fat32_root_dir}"
+
+	# Kernel and initrd go directly in the root of the FAT32 partition
+	cp -vp "out/hook/${hook_files['kernel']}" "${fat32_root_dir}/vmlinuz"
+	cp -vp "out/hook/${hook_files['initrd']}" "${fat32_root_dir}/initrd.img"
+
+	# Handle DTBs
+	if [[ "${has_dtbs}" == "yes" ]]; then
+		mkdir -p "${fat32_root_dir}/dtb"
+		tar -C "${fat32_root_dir}/dtb" --strip-components=1 -xzf "out/hook/${hook_files["dtbs"]}"
+		tree "${fat32_root_dir}"
+	fi
+
+	### @TODO: obtain and write grub binary to EFI directory
+	### @TODO: write grub.cfg
+
+	# Show the state
+	du -h -d 1 "${bootable_base_dir}"
+	tree "${bootable_base_dir}"
+
+	# Use a Dockerfile to assemble a GPT image, with a single FAT32 partition, containing the files in the fat32-root directory
+	# This is common across all GPT-based bootable media; the only difference is the ESP flag, which is set for UEFI bootable media.
+	esp_partitition="yes" \
+		create_image_fat32_root_from_dir "${bootable_base_dir}" "${bootable_img}" "${bootable_dir}/fat32-root"
+
+	log info "Show info about produced image..."
+	ls -lah "${bootable_base_dir}/${bootable_img}"
+
+	log info "Done building grub bootable for hook ${hook_id}"
+	output_bootable_media "${bootable_base_dir}/${bootable_img}" "hook-bootable-grub-${OUTPUT_ID}.img"
+
+	return 0
+
+}

--- a/bash/bootable/grub.sh
+++ b/bash/bootable/grub.sh
@@ -75,7 +75,7 @@ function build_bootable_grub() {
 
 	# Show the state
 	du -h -d 1 "${bootable_base_dir}"
-	tree "${bootable_base_dir}"
+	log_tree "${bootable_base_dir}" "debug" "State of the bootable directory"
 
 	# Use a Dockerfile to assemble a GPT image, with a single FAT32 partition, containing the files in the fat32-root directory
 	# This is common across all GPT-based bootable media; the only difference is the ESP flag, which is set for UEFI bootable media.
@@ -112,5 +112,5 @@ function download_grub_binaries_from_linuxkit_docker_images() {
 	docker buildx build --output "type=local,dest=${output_dir}" "--progress=${DOCKER_BUILDX_PROGRESS_TYPE}" -f "${grub_grabber_dockerfile}" bootable
 
 	log info "Done, GRUB binaries are in ${output_dir}"
-	tree "${output_dir}"
+	log_tree "${output_dir}" "debug" "State of the GRUB binaries directory"
 }

--- a/bash/bootable/grub.sh
+++ b/bash/bootable/grub.sh
@@ -14,7 +14,7 @@ function build_bootable_grub() {
 
 	declare hook_id="${bootable_info['INVENTORY_ID']}"
 	declare bootable_img="bootable_grub_${OUTPUT_ID}.img"
-	declare kernel_command_line="console=ttyS0" # @TODO: common stuff for tink, etc
+	declare kernel_command_line="console=${bootable_info['SERIAL_CONSOLE']}" # @TODO: common stuff for tink, etc
 
 	declare has_dtbs="${bootable_info['DTB']}"
 	[[ -z "${has_dtbs}" ]] && has_dtbs="no"

--- a/bash/bootable/grub.sh
+++ b/bash/bootable/grub.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
 function list_bootable_grub() {
+	: "${bootable_info['BOOTABLE_ID']:?"bootable_info['BOOTABLE_ID'] is unset"}"
 	declare -g -A bootable_boards=()
-	bootable_boards["generic"]="NOT=used" # A single, generic "board" for all grub bootables
+	declare board_name="${bootable_info['BOOTABLE_ID']}-generic"
+	bootable_boards["${board_name}"]="NOT=used" # A single, generic "board" for all grub bootables
 }
 
 function build_bootable_grub() {

--- a/bash/bootable/grub.sh
+++ b/bash/bootable/grub.sh
@@ -64,6 +64,15 @@ function build_bootable_grub() {
 
 	download_grub_binaries_from_linuxkit_docker_images "${fat32_efi_dir}" "${grub_arch}" "${grub_linuxkit_image}"
 
+	cat <<- GRUB_CFG > "${fat32_efi_dir}/grub.cfg"
+		set timeout=0
+		set gfxpayload=text
+		menuentry 'Tinkerbell Hook' {
+			linux /vmlinuz ${kernel_command_line}
+			initrd /initrd.img
+		}
+	GRUB_CFG
+
 	# Show the state
 	du -h -d 1 "${bootable_base_dir}"
 	tree "${bootable_base_dir}"

--- a/bash/bootable/grub.sh
+++ b/bash/bootable/grub.sh
@@ -12,7 +12,7 @@ function build_bootable_grub() {
 
 	declare hook_id="${bootable_info['INVENTORY_ID']}"
 	declare bootable_img="bootable_grub_${OUTPUT_ID}.img"
-	declare kernel_command_line="" # @TODO: common stuff for tink, etc
+	declare kernel_command_line="console=ttyS0" # @TODO: common stuff for tink, etc
 
 	declare has_dtbs="${bootable_info['DTB']}"
 	[[ -z "${has_dtbs}" ]] && has_dtbs="no"

--- a/bash/bootable/rpi.sh
+++ b/bash/bootable/rpi.sh
@@ -41,12 +41,13 @@ function build_bootable_rpi_firmware() {
 	# Handle DTBs for rpi
 	mkdir -p "${fat32_root_dir}/dtb"
 	tar -C "${fat32_root_dir}/dtb" --strip-components=1 -xzf "out/hook/dtbs-${hook_id}.tar.gz"
-	tree "${fat32_root_dir}"
+	log_tree "${fat32_root_dir}" "debug" "State of the FAT32 directory pre-moving DTBs"
 
 	# RPi: put DTBs directly in the fat32-root directory; overlays go into a subdirectory
 	mv -v "${fat32_root_dir}/dtb/overlays" "${fat32_root_dir}/overlays"
 	mv -v "${fat32_root_dir}/dtb/broadcom"/*.dtb "${fat32_root_dir}/"
 	rm -rf "${fat32_root_dir}/dtb"
+	log_tree "${fat32_root_dir}" "debug" "State of the FAT32 directory post-moving DTBs"
 
 	# Write the Raspberry Pi firmware files
 	rpi_write_binary_firmware_from_rpi_foundation "${fat32_root_dir}"

--- a/bash/bootable/rpi.sh
+++ b/bash/bootable/rpi.sh
@@ -1,0 +1,139 @@
+function list_bootable_rpi_firmware() {
+	declare -g -A bootable_boards=()
+	bootable_boards["rpi"]="NOT=used"
+}
+
+function build_bootable_rpi_firmware() {
+	: "${bootable_info['INVENTORY_ID']:?"bootable_info['INVENTORY_ID'] is unset"}"
+
+	declare hook_id="${bootable_info['INVENTORY_ID']}"
+
+	declare -A hook_files=(
+		["kernel"]="vmlinuz-${hook_id}"
+		["initrd"]="initramfs-${hook_id}"
+		["dtbs"]="dtbs-${hook_id}.tar.gz"
+	)
+
+	# Check if all the required files are present; if not, give instructions on how to build kernel and hook $hook_id
+	for file in "${!hook_files[@]}"; do
+		if [[ ! -f "out/hook/${hook_files[$file]}" ]]; then
+			log error "Required file 'out/hook/${hook_files[$file]}' not found; please build the kernel and hook ${hook_id} first: ./build.sh kernel ${hook_id} && ./build.sh build ${hook_id}"
+			exit 1
+		fi
+	done
+
+	log info "Building rpi for hook ${hook_id}"
+
+	# Prepare the base working directory in bootable/
+	declare bootable_dir="rpi"
+	declare bootable_base_dir="bootable/${bootable_dir}"
+	rm -rf "${bootable_base_dir}"
+	mkdir -p "${bootable_base_dir}"
+
+	# Prepare a directory that will be the root of the FAT32 partition
+	declare fat32_root_dir="${bootable_base_dir}/fat32-root"
+	mkdir -p "${fat32_root_dir}"
+
+	# Kernel and initrd go directly in the root of the FAT32 partition
+	cp -vp "out/hook/vmlinuz-${hook_id}" "${fat32_root_dir}/vmlinuz"
+	cp -vp "out/hook/initramfs-${hook_id}" "${fat32_root_dir}/initrd.img"
+
+	# Handle DTBs for rpi
+	mkdir -p "${fat32_root_dir}/dtb"
+	tar -C "${fat32_root_dir}/dtb" --strip-components=1 -xzf "out/hook/dtbs-${hook_id}.tar.gz"
+	tree "${fat32_root_dir}"
+
+	# RPi: put DTBs directly in the fat32-root directory; overlays go into a subdirectory
+	mv -v "${fat32_root_dir}/dtb/overlays" "${fat32_root_dir}/overlays"
+	mv -v "${fat32_root_dir}/dtb/broadcom"/*.dtb "${fat32_root_dir}/"
+	rm -rf "${fat32_root_dir}/dtb"
+
+	# Write the Raspberry Pi firmware files
+	rpi_write_binary_firmware_from_rpi_foundation "${fat32_root_dir}"
+	rpi_write_config_txt "${fat32_root_dir}"
+	rpi_write_cmdline_txt "${fat32_root_dir}"
+
+	# Show the state
+	du -h -d 1 "${bootable_base_dir}"
+	tree "${bootable_base_dir}"
+
+	# Use a Dockerfile to assemble a GPT image, with a single FAT32 partition, containing the files in the fat32-root directory
+	# This is common across all GPT-based bootable media; the only difference is the ESP flag, which is set for UEFI bootable media but not for Rockchip/RaspberryPi
+	# The u-boot binaries are written _later_ in the process, after the image is created, using Armbian's helper scripts.
+	create_image_fat32_root_from_dir "${bootable_base_dir}" "bootable-media-rpi.img" "${bootable_dir}/fat32-root"
+
+	log info "Show info about produced image..."
+	ls -lah "${bootable_base_dir}/bootable-media-rpi.img"
+
+	log info "Done building rpi bootable for hook ${hook_id}"
+	output_bootable_media "${bootable_base_dir}/bootable-media-rpi.img" "hook-bootable-rpi.img"
+
+	return 0
+
+}
+
+function rpi_write_binary_firmware_from_rpi_foundation() {
+	declare rpi_firmware_base_url="https://raw.githubusercontent.com/raspberrypi/firmware/refs/tags/1.20241126/boot/"
+
+	declare fat32_root_dir="${1}"
+	declare -a rpi_firmware_files=(
+		"bootcode.bin"
+		"fixup4cd.dat"
+		"fixup4.dat"
+		"fixup4db.dat"
+		"fixup4x.dat"
+		"fixup_cd.dat"
+		"fixup.dat"
+		"fixup_db.dat"
+		"fixup_x.dat"
+		"LICENCE.broadcom"
+		"start4cd.elf"
+		"start4db.elf"
+		"start4.elf"
+		"start4x.elf"
+		"start_cd.elf"
+		"start_db.elf"
+		"start.elf"
+		"start_x.elf"
+	)
+	# Download the Raspberry Pi firmware files from the Raspberry Pi Foundation's GitHub repo:
+	for file in "${rpi_firmware_files[@]}"; do
+		log info "Downloading ${file}..."
+		curl -sL -o "${fat32_root_dir}/${file}" "${rpi_firmware_base_url}/${file}"
+	done
+
+	return 0
+}
+
+function rpi_write_config_txt() {
+	declare fat32_root_dir="${1}"
+	cat <<- RPI_CONFIG_TXT > "${fat32_root_dir}/config.txt"
+		# For more options and information see http://rptl.io/configtxt
+		# Automatically load initramfs files, if found
+		auto_initramfs=1
+		# bootloader logs to serial, second stage
+		enable_uart=1
+		# if uart is enabled, disable Bluetooth which also uses UART
+		dtoverlay=disable-bt
+		dtoverlay=vc4-kms-v3d
+		max_framebuffers=2
+		disable_fw_kms_setup=1
+		disable_overscan=1
+		arm_boost=1
+		[cm4]
+		otg_mode=1
+		[cm5]
+		dtoverlay=dwc2,dr_mode=host
+		[all]
+		kernel=vmlinuz
+		initramfs initrd.img followkernel
+		arm_64bit=1
+	RPI_CONFIG_TXT
+}
+
+function rpi_write_cmdline_txt() {
+	declare fat32_root_dir="${1}"
+	cat <<- RPI_CMDLINE_TXT > "${fat32_root_dir}/cmdline.txt"
+		console=tty1 console=ttyAMA0,115200 loglevel=7 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory
+	RPI_CMDLINE_TXT
+}

--- a/bash/common.sh
+++ b/bash/common.sh
@@ -39,6 +39,11 @@ function install_dependencies() {
 		brew_pkgs+=("pixz")
 	}
 
+	command -v pv > /dev/null || {
+		debian_pkgs+=("pv")
+		brew_pkgs+=("pv")
+	}
+
 	command -v envsubst > /dev/null || {
 		debian_pkgs+=("gettext-base")
 		brew_pkgs+=("gettext")

--- a/bash/common.sh
+++ b/bash/common.sh
@@ -20,6 +20,20 @@ function log() {
 	echo -e "${emoji} ${ansi_reset}[${color}${level}${ansi_reset}] ${color}${*}${ansi_reset}" >&2
 }
 
+# Helper for debugging directory trees;
+function log_tree() {
+	declare directory="${1}"
+	shift
+	declare level="${1}"
+	[[ "${level}" == "debug" && "${DEBUG}" != "yes" ]] && return # Skip debugs unless DEBUG=yes is set in the environment
+	log "${@}" "-- directory ${directory}:"
+	if command -v tree > /dev/null; then
+		tree "${directory}"
+	else
+		log "${level}" "'tree' utility not installed; install it to see directory structure in logs."
+	fi
+}
+
 function install_dependencies() {
 	declare -a debian_pkgs=()
 	declare -a brew_pkgs=()

--- a/bash/common.sh
+++ b/bash/common.sh
@@ -35,6 +35,8 @@ function log_tree() {
 }
 
 function install_dependencies() {
+	declare extra="${1}"
+
 	declare -a debian_pkgs=()
 	declare -a brew_pkgs=()
 
@@ -48,20 +50,22 @@ function install_dependencies() {
 		brew_pkgs+=("pigz")
 	}
 
-	command -v pixz > /dev/null || {
-		debian_pkgs+=("pixz")
-		brew_pkgs+=("pixz")
-	}
-
-	command -v pv > /dev/null || {
-		debian_pkgs+=("pv")
-		brew_pkgs+=("pv")
-	}
-
 	command -v envsubst > /dev/null || {
 		debian_pkgs+=("gettext-base")
 		brew_pkgs+=("gettext")
 	}
+
+	if [[ "${extra}" == "bootable-media" ]]; then
+		command -v pixz > /dev/null || {
+			debian_pkgs+=("pixz")
+			brew_pkgs+=("pixz")
+		}
+
+		command -v pv > /dev/null || {
+			debian_pkgs+=("pv")
+			brew_pkgs+=("pv")
+		}
+	fi
 
 	if [[ "$(uname)" == "Darwin" ]]; then
 		command -v gtar > /dev/null || brew_pkgs+=("gnu-tar")
@@ -91,11 +95,13 @@ function install_dependencies() {
 			brew install "${brew_pkgs[@]}"
 		fi
 
-		# Re-export PATH with the gnu-version of coreutils, tar, and sed
-		declare brew_prefix
-		brew_prefix="$(brew --prefix)"
-		export PATH="${brew_prefix}/opt/gnu-sed/libexec/gnubin:${brew_prefix}/opt/gnu-tar/libexec/gnubin:${brew_prefix}/opt/coreutils/libexec/gnubin:${PATH}"
-		log debug "Darwin; PATH is now: ${PATH}"
+		if [[ "${extra}" == "" ]]; then # Do not to this if extra dependencies are being installed
+			# Re-export PATH with the gnu-version of coreutils, tar, and sed
+			declare brew_prefix
+			brew_prefix="$(brew --prefix)"
+			export PATH="${brew_prefix}/opt/gnu-sed/libexec/gnubin:${brew_prefix}/opt/gnu-tar/libexec/gnubin:${brew_prefix}/opt/coreutils/libexec/gnubin:${PATH}"
+			log debug "Darwin; PATH is now: ${PATH}"
+		fi
 	fi
 
 	return 0

--- a/bash/common.sh
+++ b/bash/common.sh
@@ -34,6 +34,11 @@ function install_dependencies() {
 		brew_pkgs+=("pigz")
 	}
 
+	command -v pixz > /dev/null || {
+		debian_pkgs+=("pixz")
+		brew_pkgs+=("pixz")
+	}
+
 	command -v envsubst > /dev/null || {
 		debian_pkgs+=("gettext-base")
 		brew_pkgs+=("gettext")

--- a/bash/common.sh
+++ b/bash/common.sh
@@ -164,6 +164,8 @@ function add_bootable_id() {
 		dict["INVENTORY_ID"]="${last_defined_id}"
 	fi
 
+	dict["BOOTABLE_ID"]="${id}"
+
 	# Sanity checking: METHOD, ARCH and TAG are required.
 	if [[ -z "${dict['HANDLER']}" || -z "${dict['TAG']}" ]]; then
 		log error "Bootable definition for id=${id} is missing HANDLER or TAG"

--- a/bash/common.sh
+++ b/bash/common.sh
@@ -49,7 +49,7 @@ function install_dependencies() {
 	if [[ ${#debian_pkgs[@]} -gt 0 ]]; then
 		# If running on Debian or Ubuntu...
 		if [[ -f /etc/debian_version ]]; then
-			log warn "Installing apt dependencies: ${debian_pkgs[*]}"
+			log info "Installing apt dependencies: ${debian_pkgs[*]}"
 			sudo DEBIAN_FRONTEND=noninteractive apt -o "Dpkg::Use-Pty=0" -y update
 			sudo DEBIAN_FRONTEND=noninteractive apt -o "Dpkg::Use-Pty=0" -y install "${debian_pkgs[@]}"
 		elif [[ "$(uname)" == "Darwin" ]]; then

--- a/bash/inventory.sh
+++ b/bash/inventory.sh
@@ -27,8 +27,11 @@ function produce_default_kernel_inventory() {
 	## Hook default kernel, source code stored in `kernel` dir in this repo -- currently 5.10.y
 	define_id "hook-default-amd64" METHOD='default' ARCH='x86_64' TAG='standard' SUPPORTS_ISO='yes' \
 		KERNEL_MAJOR='5' KERNEL_MINOR='10' KCONFIG='generic'
+	add_bootable_id "grub-amd64" HANDLER='grub' TAG='standard'
+
 	define_id "hook-default-arm64" METHOD='default' ARCH='aarch64' TAG='standard' SUPPORTS_ISO='yes' \
 		KERNEL_MAJOR='5' KERNEL_MINOR='10' KCONFIG='generic'
+	add_bootable_id "grub-arm64" HANDLER='grub' DTB='yes' TAG='standard'
 
 	## A 'peg' is not really a 'hook': for development purposes; testing new LK version and simpler LK configurations, using the default kernel
 	define_id "peg-default-amd64" METHOD='default' ARCH='x86_64' TAG='dev' \

--- a/bash/inventory.sh
+++ b/bash/inventory.sh
@@ -53,16 +53,20 @@ function produce_armbian_kernel_inventory() {
 	### SBC-oriented:
 	## Armbian meson64 (Amlogic) edge Khadas VIM3/3L, Radxa Zero/2, LibreComputer Potatos, and many more
 	define_id "armbian-meson64-edge" METHOD='armbian' ARCH='aarch64' TAG='armbian-sbc' ARMBIAN_KERNEL_ARTIFACT='kernel-meson64-edge'
+	add_bootable_id "uboot-aml" HANDLER='armbian_uboot_amlogic' TAG='armbian-sbc' UBOOT_TYPE='extlinux' CONSOLE_EXTRA_ARGS=',115200' # all meson64, mainline kernel and u-boot, uses extlinux to boot
 
 	## Armbian bcm2711 (Broadcom) current, from RaspberryPi Foundation with many CNCF-landscape fixes and patches; for the RaspberryPi 3b+/4b/5
 	define_id "armbian-bcm2711-current" METHOD='armbian' ARCH='aarch64' TAG='armbian-sbc' ARMBIAN_KERNEL_ARTIFACT='kernel-bcm2711-current'
+	add_bootable_id "rpi" HANDLER='rpi_firmware' TAG='armbian-sbc'
 
 	## Armbian rockchip64 (Rockchip) edge, for many rk356x/3399 SoCs. As of late December 2024, also for rk3588.
 	define_id "armbian-rockchip64-edge" METHOD='armbian' ARCH='aarch64' TAG='armbian-sbc' ARMBIAN_KERNEL_ARTIFACT='kernel-rockchip64-edge'
+	add_bootable_id "uboot-rk" HANDLER='armbian_uboot_rockchip' TAG='armbian-sbc' UBOOT_TYPE='extlinux' CONSOLE_EXTRA_ARGS=',1500000' # rk3588, mainline u-boot, uses extlinux to boot
 
 	## Armbian rk35xx (Rockchip) vendor, for rk3566, rk3568, rk3588, rk3588s SoCs -- 6.1-rkr4.1 - BSP / vendor kernel, roughly equivalent to Android's 6.1.84
 	# Use with edk2 (v0.9.1+) or mainline u-boot + EFI: matches the DT included in https://github.com/edk2-porting/edk2-rk3588 _after_ v0.9.1
 	define_id "armbian-rk35xx-vendor" METHOD='armbian' ARCH='aarch64' TAG='armbian-sbc' ARMBIAN_KERNEL_ARTIFACT='kernel-rk35xx-vendor'
+	add_bootable_id "uboot-rk35xx-vendor" HANDLER='armbian_uboot_rockchip_vendor' TAG='armbian-sbc' CONSOLE_EXTRA_ARGS=',1500000'
 
 	###  Armbian mainline Generic UEFI kernels, for EFI capable machines might use those:
 	## Armbian generic edge UEFI kernel for arm64

--- a/bash/inventory.sh
+++ b/bash/inventory.sh
@@ -27,11 +27,11 @@ function produce_default_kernel_inventory() {
 	## Hook default kernel, source code stored in `kernel` dir in this repo -- currently 5.10.y
 	define_id "hook-default-amd64" METHOD='default' ARCH='x86_64' TAG='standard' SUPPORTS_ISO='yes' \
 		KERNEL_MAJOR='5' KERNEL_MINOR='10' KCONFIG='generic'
-	add_bootable_id "grub-amd64" HANDLER='grub' TAG='standard'
+	add_bootable_id "grub-amd64" HANDLER='grub' SERIAL_CONSOLE='ttyS0' TAG='standard'
 
 	define_id "hook-default-arm64" METHOD='default' ARCH='aarch64' TAG='standard' SUPPORTS_ISO='yes' \
 		KERNEL_MAJOR='5' KERNEL_MINOR='10' KCONFIG='generic'
-	add_bootable_id "grub-arm64" HANDLER='grub' DTB='yes' TAG='standard'
+	add_bootable_id "grub-arm64" HANDLER='grub' SERIAL_CONSOLE='ttyAMA0' DTB='yes' TAG='standard'
 
 	## A 'peg' is not really a 'hook': for development purposes; testing new LK version and simpler LK configurations, using the default kernel
 	define_id "peg-default-amd64" METHOD='default' ARCH='x86_64' TAG='dev' \
@@ -41,11 +41,11 @@ function produce_default_kernel_inventory() {
 	## development purposes: trying out kernel 6.6.y
 	define_id "hook-latest-lts-amd64" METHOD='default' ARCH='x86_64' TAG='lts' SUPPORTS_ISO='yes' \
 		KERNEL_MAJOR='6' KERNEL_MINOR='6' KCONFIG='generic' FORCE_OUTPUT_ID='latest-lts'
-	add_bootable_id "grub-latest-lts-amd64" HANDLER='grub' TAG='lts'
+	add_bootable_id "grub-latest-lts-amd64" SERIAL_CONSOLE='ttyS0' HANDLER='grub' TAG='lts'
 
 	define_id "hook-latest-lts-arm64" METHOD='default' ARCH='aarch64' TAG='lts' SUPPORTS_ISO='yes' \
 		KERNEL_MAJOR='6' KERNEL_MINOR='6' KCONFIG='generic' FORCE_OUTPUT_ID='latest-lts'
-	add_bootable_id "grub-latest-lts-arm64" HANDLER='grub' DTB='yes' TAG='lts'
+	add_bootable_id "grub-latest-lts-arm64" SERIAL_CONSOLE='ttyAMA0' HANDLER='grub' DTB='yes' TAG='lts'
 }
 
 ##### METHOD=armbian; Foreign kernels, taken from Armbian's OCI repos. Those are "exotic" kernels for certain SoC's.
@@ -77,9 +77,9 @@ function produce_armbian_kernel_inventory() {
 	###  Armbian mainline Generic UEFI kernels, for EFI capable machines might use those:
 	## Armbian generic edge UEFI kernel for arm64
 	define_id "armbian-uefi-arm64-edge" METHOD='armbian' ARCH='aarch64' TAG='standard armbian-uefi' ARMBIAN_KERNEL_ARTIFACT='kernel-arm64-edge'
-	add_bootable_id "grub-armbian-uefi-arm64" HANDLER='grub' DTB='yes' TAG='standard'
+	add_bootable_id "grub-armbian-uefi-arm64" HANDLER='grub' SERIAL_CONSOLE='ttyAMA0' DTB='yes' TAG='standard'
 
 	## Armbian generic edge UEFI kernel (Armbian calls it x86)
 	define_id "armbian-uefi-x86-edge" METHOD='armbian' ARCH='x86_64' TAG='standard armbian-uefi' ARMBIAN_KERNEL_ARTIFACT='kernel-x86-edge'
-	add_bootable_id "grub-armbian-uefi-amd64" HANDLER='grub' TAG='standard'
+	add_bootable_id "grub-armbian-uefi-amd64" HANDLER='grub' SERIAL_CONSOLE='ttyS0' TAG='standard'
 }

--- a/bash/inventory.sh
+++ b/bash/inventory.sh
@@ -77,7 +77,9 @@ function produce_armbian_kernel_inventory() {
 	###  Armbian mainline Generic UEFI kernels, for EFI capable machines might use those:
 	## Armbian generic edge UEFI kernel for arm64
 	define_id "armbian-uefi-arm64-edge" METHOD='armbian' ARCH='aarch64' TAG='standard armbian-uefi' ARMBIAN_KERNEL_ARTIFACT='kernel-arm64-edge'
+	add_bootable_id "grub-armbian-uefi-arm64" HANDLER='grub' DTB='yes' TAG='standard'
 
 	## Armbian generic edge UEFI kernel (Armbian calls it x86)
 	define_id "armbian-uefi-x86-edge" METHOD='armbian' ARCH='x86_64' TAG='standard armbian-uefi' ARMBIAN_KERNEL_ARTIFACT='kernel-x86-edge'
+	add_bootable_id "grub-armbian-uefi-amd64" HANDLER='grub' TAG='standard'
 }

--- a/bash/inventory.sh
+++ b/bash/inventory.sh
@@ -41,8 +41,11 @@ function produce_default_kernel_inventory() {
 	## development purposes: trying out kernel 6.6.y
 	define_id "hook-latest-lts-amd64" METHOD='default' ARCH='x86_64' TAG='lts' SUPPORTS_ISO='yes' \
 		KERNEL_MAJOR='6' KERNEL_MINOR='6' KCONFIG='generic' FORCE_OUTPUT_ID='latest-lts'
+	add_bootable_id "grub-latest-lts-amd64" HANDLER='grub' TAG='lts'
+
 	define_id "hook-latest-lts-arm64" METHOD='default' ARCH='aarch64' TAG='lts' SUPPORTS_ISO='yes' \
 		KERNEL_MAJOR='6' KERNEL_MINOR='6' KCONFIG='generic' FORCE_OUTPUT_ID='latest-lts'
+	add_bootable_id "grub-latest-lts-arm64" HANDLER='grub' DTB='yes' TAG='lts'
 }
 
 ##### METHOD=armbian; Foreign kernels, taken from Armbian's OCI repos. Those are "exotic" kernels for certain SoC's.

--- a/bash/inventory.sh
+++ b/bash/inventory.sh
@@ -2,6 +2,7 @@
 
 function produce_kernels_flavours_inventory() {
 	declare -g -A inventory_dict=()
+	declare -g -A bootable_inventory_dict=()
 
 	produce_default_kernel_inventory
 	produce_armbian_kernel_inventory
@@ -13,8 +14,10 @@ function produce_kernels_flavours_inventory() {
 	fi
 
 	# extract keys & make readonly
-	declare -g -a -r inventory_ids=("${!inventory_dict[@]}") # extract the _keys_ from the inventory_ids dict
-	declare -g -A -r inventory_dict                          # make kernels_data dict readonly
+	declare -g -a -r inventory_ids=("${!inventory_dict[@]}")                   # extract the _keys_ from the inventory_ids dict
+	declare -g -A -r inventory_dict                                            # make kernels_data dict readonly
+	declare -g -a -r bootable_inventory_ids=("${!bootable_inventory_dict[@]}") # extract the _keys_ from the inventory_ids dict
+	declare -g -A -r bootable_inventory_dict                                   # make kernels_data dict readonly
 
 	return 0
 }

--- a/bash/inventory.sh
+++ b/bash/inventory.sh
@@ -31,7 +31,7 @@ function produce_default_kernel_inventory() {
 
 	define_id "hook-default-arm64" METHOD='default' ARCH='aarch64' TAG='standard' SUPPORTS_ISO='yes' \
 		KERNEL_MAJOR='5' KERNEL_MINOR='10' KCONFIG='generic'
-	add_bootable_id "grub-arm64" HANDLER='grub' SERIAL_CONSOLE='ttyAMA0' DTB='yes' TAG='standard'
+	add_bootable_id "grub-arm64" HANDLER='grub' SERIAL_CONSOLE='ttyAMA0' TAG='standard'
 
 	## A 'peg' is not really a 'hook': for development purposes; testing new LK version and simpler LK configurations, using the default kernel
 	define_id "peg-default-amd64" METHOD='default' ARCH='x86_64' TAG='dev' \
@@ -45,7 +45,7 @@ function produce_default_kernel_inventory() {
 
 	define_id "hook-latest-lts-arm64" METHOD='default' ARCH='aarch64' TAG='lts' SUPPORTS_ISO='yes' \
 		KERNEL_MAJOR='6' KERNEL_MINOR='6' KCONFIG='generic' FORCE_OUTPUT_ID='latest-lts'
-	add_bootable_id "grub-latest-lts-arm64" SERIAL_CONSOLE='ttyAMA0' HANDLER='grub' DTB='yes' TAG='lts'
+	add_bootable_id "grub-latest-lts-arm64" SERIAL_CONSOLE='ttyAMA0' HANDLER='grub' TAG='lts'
 }
 
 ##### METHOD=armbian; Foreign kernels, taken from Armbian's OCI repos. Those are "exotic" kernels for certain SoC's.

--- a/bash/kernel.sh
+++ b/bash/kernel.sh
@@ -13,6 +13,14 @@ function obtain_kernel_data_from_id() {
 	return 0
 }
 
+function kernel_obtain_output_id() {
+	log debug "Running obtain output id method: ${kernel_info[OUTPUT_ID_FUNC]}"
+	"${kernel_info[OUTPUT_ID_FUNC]}"
+
+	return 0
+
+}
+
 function kernel_calculate_version() {
 	log debug "Running calculate version method: ${kernel_info[VERSION_FUNC]}"
 	"${kernel_info[VERSION_FUNC]}"
@@ -106,6 +114,7 @@ function get_kernel_info_dict() {
 	# Post process
 	kernel_info['BUILD_FUNC']="build_kernel_${kernel_info['METHOD']}"
 	kernel_info['VERSION_FUNC']="calculate_kernel_version_${kernel_info['METHOD']}"
+	kernel_info['OUTPUT_ID_FUNC']="obtain_kernel_output_id_${kernel_info['METHOD']}"
 	kernel_info['CONFIG_FUNC']="configure_kernel_${kernel_info['METHOD']}"
 
 	# Defaults for optional settings

--- a/bash/kernel.sh
+++ b/bash/kernel.sh
@@ -73,7 +73,7 @@ function resolve_latest_kernel_version_lts() { # Produces KERNEL_POINT_RELEASE
 		log debug "Found disk cached kernel-releases.json"
 		# if the cache is older than 2 hours, refresh it
 		if [[ "$(find "${CACHE_DIR}/kernel-releases.json" -mmin +120)" ]]; then
-			log warn "Cached kernel-releases.json is older than 2 hours, will refresh..."
+			log info "Cached kernel-releases.json is older than 2 hours, will refresh..."
 		else
 			log info "Using cached kernel-releases.json"
 			cache_valid=1

--- a/bash/kernel/kernel_armbian.sh
+++ b/bash/kernel/kernel_armbian.sh
@@ -36,7 +36,7 @@ function calculate_kernel_version_armbian() {
 		FROM debian:stable AS downloader
 		# Call the helper to install curl, oras, and dpkg-dev
 		ADD ./${dockerfile_helper_filename} /apt-oras-helper.sh
-		RUN bash /apt-oras-helper.sh dpkg-dev
+		RUN bash /apt-oras-helper.sh
 
 		FROM downloader AS downloaded
 

--- a/bash/kernel/kernel_armbian.sh
+++ b/bash/kernel/kernel_armbian.sh
@@ -73,7 +73,8 @@ function calculate_kernel_version_armbian() {
 		RUN tar -cf /armbian/output/kernel.tar .
 
 		# Create a tarball with the dtbs in usr/lib/linux-image-*
-		RUN { cd usr/lib/linux-image-* || { echo "No DTBS for this arch, empty tar..." && mkdir -p usr/lib/linux-image-no-dtbs && cd usr/lib/linux-image-* ; } ; }  && pwd && du -h -d 1 . && tar -czvf /armbian/output/dtbs.tar.gz . && ls -lah /armbian/output/dtbs.tar.gz
+		WORKDIR /armbian/image
+		RUN {  cd usr/lib/linux-image-* || { echo "No DTBS for this arch, empty tar..." && mkdir -p usr/lib/linux-image-no-dtbs && cd usr/lib/linux-image-* ; } ; }  && pwd && du -h -d 1 . && tar -czf /armbian/output/dtbs.tar.gz . && ls -lah /armbian/output/dtbs.tar.gz
 
 		# Show the contents of the output dir
 		WORKDIR /armbian/output

--- a/bash/kernel/kernel_armbian.sh
+++ b/bash/kernel/kernel_armbian.sh
@@ -2,6 +2,12 @@
 
 declare -g ARMBIAN_BASE_ORAS_REF="${ARMBIAN_BASE_ORAS_REF:-"ghcr.io/armbian/os"}"
 
+function obtain_kernel_output_id_armbian() {
+	: "${inventory_id:?"ERROR: inventory_id is not defined"}"
+	# output ID is just the inventory_id
+	declare -g OUTPUT_ID="${inventory_id}"
+}
+
 function calculate_kernel_version_armbian() {
 	: "${inventory_id:?"ERROR: inventory_id is not defined"}"
 	log info "Calculating version of Armbian kernel..."
@@ -17,8 +23,7 @@ function calculate_kernel_version_armbian() {
 		log info "Using most recent Armbian kernel tag: ${ARMBIAN_KERNEL_VERSION}"
 	fi
 
-	# output ID is just the inventory_id
-	declare -g OUTPUT_ID="${inventory_id}"
+	obtain_kernel_output_id_armbian
 
 	declare -g ARMBIAN_KERNEL_FULL_ORAS_REF_DEB_TAR="${ARMBIAN_KERNEL_BASE_ORAS_REF}:${ARMBIAN_KERNEL_VERSION}"
 	declare -g ARMBIAN_KERNEL_MAJOR_MINOR_POINT="unknown"

--- a/bash/kernel/kernel_default.sh
+++ b/bash/kernel/kernel_default.sh
@@ -2,18 +2,8 @@
 
 set -e
 
-function calculate_kernel_version_default() {
-	# Make sure inventory_id is defined or exit with an error; using a one liner
+function obtain_kernel_output_id_default() {
 	: "${inventory_id:?"ERROR: inventory_id is not defined"}"
-	log debug "Starting calculate_kernel_version_default for inventory_id='${inventory_id}'"
-
-	# Calculate the input DEFCONFIG
-	declare -g INPUT_DEFCONFIG="${KCONFIG}-${KERNEL_MAJOR}.${KERNEL_MINOR}.y-${ARCH}"
-	if [[ ! -f "kernel/configs/${INPUT_DEFCONFIG}" ]]; then
-		log error "kernel/configs/${INPUT_DEFCONFIG} does not exist, check inputs/envs"
-		exit 1
-	fi
-
 	# The default kernel output id is just the arch (for compatibility with the old hook)
 	# One can override with FORCE_OUTPUT_ID, which will be prepended to ARCH.
 	# If that is not set, and KCONFIG != generic, an output will be generated with KCONFIG, MAJOR, MINOR, ARCH.
@@ -26,6 +16,21 @@ function calculate_kernel_version_default() {
 	elif [[ -n "${USE_KERNEL_ID}" ]]; then
 		OUTPUT_ID="${inventory_id}"
 	fi
+}
+
+function calculate_kernel_version_default() {
+	# Make sure inventory_id is defined or exit with an error; using a one liner
+	: "${inventory_id:?"ERROR: inventory_id is not defined"}"
+	log debug "Starting calculate_kernel_version_default for inventory_id='${inventory_id}'"
+
+	# Calculate the input DEFCONFIG
+	declare -g INPUT_DEFCONFIG="${KCONFIG}-${KERNEL_MAJOR}.${KERNEL_MINOR}.y-${ARCH}"
+	if [[ ! -f "kernel/configs/${INPUT_DEFCONFIG}" ]]; then
+		log error "kernel/configs/${INPUT_DEFCONFIG} does not exist, check inputs/envs"
+		exit 1
+	fi
+
+	obtain_kernel_output_id_default # Sets OUTPUT_ID
 
 	# Calculate the KERNEL_ARCH from ARCH; also what is the cross-compiler package needed for the arch
 	declare -g KERNEL_ARCH="" KERNEL_CROSS_COMPILE_PKGS="" KERNEL_OUTPUT_IMAGE=""

--- a/bash/shellcheck.sh
+++ b/bash/shellcheck.sh
@@ -95,20 +95,8 @@ function download_prepare_shellfmt_bin() {
 }
 
 function run_shellcheck() {
-	declare -a params=() excludes=()
-
-	excludes+=(
-		#"SC2034" # "appears unused" -- bad, but no-one will die of this
-	)
-
-	params+=(--check-sourced --color=always --external-sources --format=tty --shell=bash)
-
-	# --severity=SEVERITY        Minimum severity of errors to consider (error, warning, info, style)
-	params+=("--severity=style") # warning is the default
-
-	for exclude in "${excludes[@]}"; do
-		params+=(--exclude="${exclude}")
-	done
+	declare -a params=()
+	params+=(--check-sourced --color=always --external-sources --format=tty --shell=bash --severity=style) # warning is the default
 
 	log info "Running shellcheck ${SHELLCHECK_ACTUAL_VERSION} against 'build.sh', please wait..."
 	log debug "All shellcheck params: " "${params[@]}"

--- a/build.sh
+++ b/build.sh
@@ -16,6 +16,7 @@ source bash/kernel.sh
 source bash/kernel/kernel_default.sh
 source bash/kernel/kernel_armbian.sh
 source bash/bootable-media.sh
+source bash/bootable/fat32-image.sh
 
 ### Initialize the command-line handling. This should behave similar to `make`; PARAM=value pairs are accepted in any order mixed with non-param arguments.
 declare -A -g CLI_PARSED_CMDLINE_PARAMS=()

--- a/build.sh
+++ b/build.sh
@@ -91,6 +91,12 @@ case "${first_param}" in
 	lint)
 		download_prepare_shellcheck_bin
 		download_prepare_shellfmt_bin
+		log info "Installing lint as pre-commit hook in git by directly creating a script in .git/hooks/pre-commit"
+		cat <<- PRE_COMMIT_HOOK > .git/hooks/pre-commit
+			#!/usr/bin/env bash
+			bash build.sh lint
+		PRE_COMMIT_HOOK
+		chmod +x .git/hooks/pre-commit
 		run_shellcheck
 		run_shellfmt # this exits with an error if changes are made
 		exit 0

--- a/build.sh
+++ b/build.sh
@@ -16,6 +16,7 @@ source bash/kernel.sh
 source bash/kernel/kernel_default.sh
 source bash/kernel/kernel_armbian.sh
 source bash/bootable-media.sh
+source bash/bootable/grub.sh
 source bash/bootable/armbian-u-boot.sh
 source bash/bootable/rpi.sh
 source bash/bootable/fat32-image.sh

--- a/build.sh
+++ b/build.sh
@@ -15,6 +15,7 @@ source bash/json-matrix.sh
 source bash/kernel.sh
 source bash/kernel/kernel_default.sh
 source bash/kernel/kernel_armbian.sh
+source bash/bootable-media.sh
 
 ### Initialize the command-line handling. This should behave similar to `make`; PARAM=value pairs are accepted in any order mixed with non-param arguments.
 declare -A -g CLI_PARSED_CMDLINE_PARAMS=()
@@ -109,6 +110,11 @@ case "${first_param}" in
 
 	linuxkit-containers)
 		build_all_hook_linuxkit_containers
+		exit 0
+		;;
+
+	bootable-media | bootable | media)
+		build_bootable_media "${CLI_NON_PARAM_ARGS[@]:1}" # this handles its own arguments, namely the bootable_id
 		exit 0
 		;;
 esac

--- a/build.sh
+++ b/build.sh
@@ -118,6 +118,7 @@ case "${first_param}" in
 		;;
 
 	bootable-media | bootable | media)
+		install_dependencies "bootable-media"             # bootable's need more dependencies (pixz, pv)
 		build_bootable_media "${CLI_NON_PARAM_ARGS[@]:1}" # this handles its own arguments, namely the bootable_id
 		exit 0
 		;;

--- a/build.sh
+++ b/build.sh
@@ -16,6 +16,7 @@ source bash/kernel.sh
 source bash/kernel/kernel_default.sh
 source bash/kernel/kernel_armbian.sh
 source bash/bootable-media.sh
+source bash/bootable/armbian-u-boot.sh
 source bash/bootable/rpi.sh
 source bash/bootable/fat32-image.sh
 

--- a/build.sh
+++ b/build.sh
@@ -16,6 +16,7 @@ source bash/kernel.sh
 source bash/kernel/kernel_default.sh
 source bash/kernel/kernel_armbian.sh
 source bash/bootable-media.sh
+source bash/bootable/rpi.sh
 source bash/bootable/fat32-image.sh
 
 ### Initialize the command-line handling. This should behave similar to `make`; PARAM=value pairs are accepted in any order mixed with non-param arguments.

--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -87,7 +87,11 @@ RUN set -x && \
     mkdir -p /tmp/kernel-dtb && \
     case "$KERNEL_ARCH" in \
     arm64) \
+        echo "Building DTBs for arm64" && \
         make -s -j"$(getconf _NPROCESSORS_ONLN)" INSTALL_DTBS_PATH=/tmp/kernel-dtb dtbs_install; \
+        ;; \
+    *) \
+        echo "No DTBs for $KERNEL_ARCH"; \
         ;; \
     esac && \
      ( cd /tmp/kernel-dtb && tar czvf /out/dtbs.tar.gz . )


### PR DESCRIPTION
>  "build and write bootable media image to SDCard/eMMC/USBkey/etc, configure kernel params, then use Tinkerbell to provision a separate NVMe/SATA/USB disk, all PXE and Smee-free"

- "L3" provisioning for small (and big) machines
- **WiP**; **RFC**.
- Still missing:
  - `0README.txt` generation for each variant
  - Taking `TINK_SERVER`/`TINK_GRPC_PORT`/`TINK_WORKER_IMAGE`/`MAC` vars/params and presetting in grub.cfg/cmdline.txt/extlinux.conf for self-builder's convenience
  - docs (ofc; at least the self-builder part, user-facing should go into `0README.txt`)
  - CI (GHA) -- I've this ready, but I'm witholding it to prove the everything else still works without changes
  - Some refactor of the temporary-Dockerfile for fat32/mtools that is being abused for the u-boot specific `mkimage`

---

How to test this?

- Build the media
  - For UEFI-capable amd64 (default 5.10 Hook kernel): `./build.sh bootable-media grub-amd64`
  - For RaspberryPi 3/4/5 (Armbian kernel): `./build.sh bootable-media rpi`
- Write the produced `.img.xz` to media (use eg the "RaspberryPi Imager" software)
- Edit `cmdline.txt` / `grub.cfg` / `extlinux.conf` on the media with a text editor, configure your kernel cmdline
- Configure your device to boot from your NVMe/SATA disk "first", and the Hook bootable-media device later
- Boot the bootable media on your device
- To reprovision, cripple your NVMe/SATA disk's boot partition or change next-boot order
---

Comments are welcome; pending stuff is coming in the next few weeks.
