### PR TITLE
hook-docker: fix: last kernel cmdline option would have a newline

### DIFF
--- a/images/hook-docker/main.go
+++ b/images/hook-docker/main.go
@@ -106,17 +106,17 @@ func parseCmdLine(cmdLines []string) (cfg tinkConfig) {
 			continue
 		}
 
-		switch cmd := cmdLine[0]; cmd {
+		switch cmd := strings.TrimSpace(cmdLine[0]); cmd {
 		case "syslog_host":
-			cfg.syslogHost = cmdLine[1]
+			cfg.syslogHost = strings.TrimSpace(cmdLine[1])
 		case "insecure_registries":
-			cfg.insecureRegistries = strings.Split(cmdLine[1], ",")
+			cfg.insecureRegistries = strings.Split(strings.TrimSpace(cmdLine[1]), ",")
 		case "HTTP_PROXY":
-			cfg.httpProxy = cmdLine[1]
+			cfg.httpProxy = strings.TrimSpace(cmdLine[1])
 		case "HTTPS_PROXY":
-			cfg.httpsProxy = cmdLine[1]
+			cfg.httpsProxy = strings.TrimSpace(cmdLine[1])
 		case "NO_PROXY":
-			cfg.noProxy = cmdLine[1]
+			cfg.noProxy = strings.TrimSpace(cmdLine[1])
 		}
 	}
 	return cfg


### PR DESCRIPTION
hook-docker: fix: last kernel cmdline option would have a newline

Example:

```
(ns: getty) HookOS 0.10.0:/var/log# cat -A /proc/cmdline
coherent_pool=1M 8250.nr_uarts=1 snd_bcm2835.enable_headphones=0 cgroup_disable=memory numa_policy=interleave snd_bcm2835.enable_hdmi=0  smsc95xx.macaddr=DC:A6:32:EC:8B:49 vc_mem.mem_base=0x3ec00000 vc_mem.mem_size=0x40000000  console=tty1 console=ttyAMA0,115200 loglevel=7 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory worker_id=rpi tink_worker_image=ghcr.io/tinkerbell/tink-agent:latest grpc_authority=tinkerbell:42113 tinkerbell_tls=false syslog_host=tinkerbell$
```

Leading to:

```
tail -f /var/log/hook-docker.log
<...snip...>
failed to start daemon: failed to set log opts: failed to set log opts: parse "udp://tinkerbell\n:514": net/url: invalid control character in URL
```

Signed-off-by: Ricardo Pardini <ricardo@pardini.net>