### PR TITLE
bootable: cleanups; config grub.cfg/extlinux.conf/cmdline.txt via environment during build

### DIFF
--- a/bash/bootable-media.sh
+++ b/bash/bootable-media.sh
@@ -1,7 +1,13 @@
 function build_bootable_media() {
-	log info "would build build_bootable_media: '${*}'"
+	log debug "would build build_bootable_media: '${*}'"
 
 	declare -r -g bootable_id="${1}" # read-only variable from here
+
+	# Check if the bootable_id is set, otherwise bomb
+	if [[ -z "${bootable_id}" ]]; then
+		log error "No bootable_id specified; please specify one of: ${bootable_inventory_ids[*]}"
+		exit 1
+	fi
 
 	declare -g -A bootable_info=()
 	get_bootable_info_dict "${bootable_id}"

--- a/bash/bootable-media.sh
+++ b/bash/bootable-media.sh
@@ -106,3 +106,28 @@ function write_image_to_device() {
 		fi
 	fi
 }
+
+function fill_array_bootable_tinkerbell_kernel_parameters() {
+	declare -g -a bootable_tinkerbell_kernel_params=() # output global var
+	declare -r board_id="${1}"                         # board_id is the first argument
+
+	declare TINK_WORKER_IMAGE="${TINK_WORKER_IMAGE:-"ghcr.io/tinkerbell/tink-agent:latest"}"
+	declare TINK_TLS="${TINK_TLS:-"false"}"
+	declare TINK_GRPC_PORT="${TINK_GRPC_PORT:-"42113"}"
+	declare TINK_SERVER="${TINK_SERVER:-"tinkerbell"}" # export TINK_SERVER="192.168.66.75"
+	declare WORKER_ID="${WORKER_ID:-"${board_id}"}"    # export WORKER_ID="11:22:33:44:55:66"
+
+	log info "WORKER_ID is set to '${WORKER_ID}'"
+	log info "TINK_WORKER_IMAGE is set to '${TINK_WORKER_IMAGE}'"
+	log info "TINK_SERVER is set to '${TINK_SERVER}'"
+	log info "TINK_TLS is set to '${TINK_TLS}'"
+	log info "TINK_GRPC_PORT is set to '${TINK_GRPC_PORT}'"
+
+	bootable_tinkerbell_kernel_params+=(
+		"worker_id=${WORKER_ID}"
+		"tink_worker_image=${TINK_WORKER_IMAGE}"
+		"grpc_authority=${TINK_SERVER}:${TINK_GRPC_PORT}"
+		"tinkerbell_tls=${TINK_TLS}"
+		"syslog_host=${TINK_SERVER}"
+	)
+}

--- a/bash/bootable-media.sh
+++ b/bash/bootable-media.sh
@@ -13,13 +13,13 @@ function build_bootable_media() {
 	get_bootable_info_dict "${bootable_id}"
 
 	# Dump the bootable_info dict
-	log info "bootable_info: $(declare -p bootable_info)"
+	log debug "bootable_info: $(declare -p bootable_info)"
 
 	# Get the kernel info from the bootable_info INVENTORY_ID
 	declare -g -A kernel_info=()
 	declare -g inventory_id="${bootable_info['INVENTORY_ID']}"
 	get_kernel_info_dict "${inventory_id}"
-	log info "kernel_info: $(declare -p kernel_info)"
+	log debug "kernel_info: $(declare -p kernel_info)"
 	set_kernel_vars_from_info_dict
 	kernel_obtain_output_id # sets OUTPUT_ID
 
@@ -82,11 +82,16 @@ function output_bootable_media() {
 		return 0
 	fi
 
+	declare human_size_input_file=""
+	human_size_input_file="$(du -h "${input_file}" | awk '{print $1}')"
+
 	# Use pixz to compress the image; use all CPU cores, default compression level
-	log info "Compressing image file ${input_file} to ${full_output_fn} -- wait..."
+	log info "Compressing image file ${input_file} (${human_size_input_file}) to ${full_output_fn} -- wait..."
 	pixz -i "${input_file}" -o "${full_output_fn}"
-	ls -lah "${full_output_fn}"
-	log info "Compressed image file ${input_file} to ${full_output_fn}"
+
+	declare human_size_output_file=""
+	human_size_output_file="$(du -h "${full_output_fn}" | awk '{print $1}')"
+	log info "Compressed image file to ${full_output_fn} (${human_size_output_file})"
 
 	return 0
 }

--- a/bash/bootable/armbian-u-boot.sh
+++ b/bash/bootable/armbian-u-boot.sh
@@ -233,6 +233,10 @@ function write_uboot_extlinux() {
 	declare bootargs="${UBOOT_EXTLINUX_CMDLINE} console=${UBOOT_KERNEL_SERIALCON}${console_extra_args}"
 	log info "Writing extlinux.conf; kernel cmdline: ${bootargs}"
 
+	declare -g -a bootable_tinkerbell_kernel_params=()
+	fill_array_bootable_tinkerbell_kernel_parameters "${BOARD}"
+	declare tinkerbell_args="${bootable_tinkerbell_kernel_params[*]}"
+
 	mkdir -p "${fat32_root_dir}/extlinux"
 	declare extlinux_conf="${fat32_root_dir}/extlinux/extlinux.conf"
 	cat <<- EXTLINUX_CONF > "${extlinux_conf}"
@@ -240,7 +244,7 @@ function write_uboot_extlinux() {
 		LABEL hook
 			linux /vmlinuz
 			initrd /initramfs
-			append ${bootargs}
+			append ${bootargs} ${tinkerbell_args}
 			fdt /dtb/${UBOOT_KERNEL_DTB}
 	EXTLINUX_CONF
 	# @TODO: fdtdir when UBOOT_KERNEL_DTB is unset

--- a/bash/bootable/armbian-u-boot.sh
+++ b/bash/bootable/armbian-u-boot.sh
@@ -28,6 +28,7 @@ function build_bootable_armbian_uboot_amlogic() {
 function list_bootable_armbian_uboot_rockchip() {
 	declare -g -A bootable_boards=()
 	bootable_boards["odroidm1"]="BOARD=odroidm1 BRANCH=edge"
+	bootable_boards["quartz64a"]="BOARD=quartz64a BRANCH=edge"
 	bootable_boards["rockpro64"]="BOARD=rockpro64 BRANCH=edge"
 	bootable_boards["nanopct6"]="BOARD=nanopct6 BRANCH=edge"
 	bootable_boards["cm3588-nas"]="BOARD=cm3588-nas BRANCH=edge"

--- a/bash/bootable/grub.sh
+++ b/bash/bootable/grub.sh
@@ -49,8 +49,8 @@ function build_bootable_grub() {
 	mkdir -p "${fat32_root_dir}"
 
 	# Kernel and initrd go directly in the root of the FAT32 partition
-	cp -vp "out/hook/${hook_files['kernel']}" "${fat32_root_dir}/vmlinuz"
-	cp -vp "out/hook/${hook_files['initrd']}" "${fat32_root_dir}/initrd.img"
+	cp -p "${debug_dash_v[@]}" "out/hook/${hook_files['kernel']}" "${fat32_root_dir}/vmlinuz"
+	cp -p "${debug_dash_v[@]}" "out/hook/${hook_files['initrd']}" "${fat32_root_dir}/initrd.img"
 
 	# Handle DTBs
 	if [[ "${has_dtbs}" == "yes" ]]; then
@@ -78,18 +78,15 @@ function build_bootable_grub() {
 		  initrd /initrd.img
 		}
 	GRUB_CFG
+	bat_language="Plain text" log_file_bat "${fat32_efi_dir}/grub.cfg" "info" "Produced GRUB grub.cfg"
 
 	# Show the state
-	du -h -d 1 "${bootable_base_dir}"
 	log_tree "${bootable_base_dir}" "debug" "State of the bootable directory"
 
 	# Use a Dockerfile to assemble a GPT image, with a single FAT32 partition, containing the files in the fat32-root directory
 	# This is common across all GPT-based bootable media; the only difference is the ESP flag, which is set for UEFI bootable media.
 	esp_partitition="yes" \
 		create_image_fat32_root_from_dir "${bootable_base_dir}" "${bootable_img}" "${bootable_dir}/fat32-root"
-
-	log info "Show info about produced image..."
-	ls -lah "${bootable_base_dir}/${bootable_img}"
 
 	log info "Done building grub bootable for hook ${hook_id}"
 	output_bootable_media "${bootable_base_dir}/${bootable_img}" "hook-bootable-grub-${OUTPUT_ID}.img"

--- a/bash/bootable/grub.sh
+++ b/bash/bootable/grub.sh
@@ -66,12 +66,16 @@ function build_bootable_grub() {
 
 	download_grub_binaries_from_linuxkit_docker_images "${fat32_efi_dir}" "${grub_arch}" "${grub_linuxkit_image}"
 
+	declare -g -a bootable_tinkerbell_kernel_params=()
+	fill_array_bootable_tinkerbell_kernel_parameters "efi-${grub_arch}"
+	declare tinkerbell_args="${bootable_tinkerbell_kernel_params[*]}"
+
 	cat <<- GRUB_CFG > "${fat32_efi_dir}/grub.cfg"
 		set timeout=0
 		set gfxpayload=text
-		menuentry 'Tinkerbell Hook' {
-			linux /vmlinuz ${kernel_command_line}
-			initrd /initrd.img
+		menuentry 'Tinkerbell Hook ${grub_arch}' {
+		  linux /vmlinuz ${kernel_command_line} ${tinkerbell_args}
+		  initrd /initrd.img
 		}
 	GRUB_CFG
 

--- a/bash/bootable/rpi.sh
+++ b/bash/bootable/rpi.sh
@@ -133,8 +133,12 @@ function rpi_write_config_txt() {
 }
 
 function rpi_write_cmdline_txt() {
+	declare -g -a bootable_tinkerbell_kernel_params=()
+	fill_array_bootable_tinkerbell_kernel_parameters "rpi"
+	declare tinkerbell_args="${bootable_tinkerbell_kernel_params[*]}"
+
 	declare fat32_root_dir="${1}"
 	cat <<- RPI_CMDLINE_TXT > "${fat32_root_dir}/cmdline.txt"
-		console=tty1 console=ttyAMA0,115200 loglevel=7 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory
+		console=tty1 console=ttyAMA0,115200 loglevel=7 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory ${tinkerbell_args}
 	RPI_CMDLINE_TXT
 }

--- a/bash/bootable/rpi.sh
+++ b/bash/bootable/rpi.sh
@@ -35,8 +35,8 @@ function build_bootable_rpi_firmware() {
 	mkdir -p "${fat32_root_dir}"
 
 	# Kernel and initrd go directly in the root of the FAT32 partition
-	cp -vp "out/hook/vmlinuz-${hook_id}" "${fat32_root_dir}/vmlinuz"
-	cp -vp "out/hook/initramfs-${hook_id}" "${fat32_root_dir}/initrd.img"
+	cp -p "${debug_dash_v[@]}" "out/hook/vmlinuz-${hook_id}" "${fat32_root_dir}/vmlinuz"
+	cp -p "${debug_dash_v[@]}" "out/hook/initramfs-${hook_id}" "${fat32_root_dir}/initrd.img"
 
 	# Handle DTBs for rpi
 	mkdir -p "${fat32_root_dir}/dtb"
@@ -44,8 +44,8 @@ function build_bootable_rpi_firmware() {
 	log_tree "${fat32_root_dir}" "debug" "State of the FAT32 directory pre-moving DTBs"
 
 	# RPi: put DTBs directly in the fat32-root directory; overlays go into a subdirectory
-	mv -v "${fat32_root_dir}/dtb/overlays" "${fat32_root_dir}/overlays"
-	mv -v "${fat32_root_dir}/dtb/broadcom"/*.dtb "${fat32_root_dir}/"
+	mv "${debug_dash_v[@]}" "${fat32_root_dir}/dtb/overlays" "${fat32_root_dir}/overlays"
+	mv "${debug_dash_v[@]}" "${fat32_root_dir}/dtb/broadcom"/*.dtb "${fat32_root_dir}/"
 	rm -rf "${fat32_root_dir}/dtb"
 	log_tree "${fat32_root_dir}" "debug" "State of the FAT32 directory post-moving DTBs"
 
@@ -54,17 +54,10 @@ function build_bootable_rpi_firmware() {
 	rpi_write_config_txt "${fat32_root_dir}"
 	rpi_write_cmdline_txt "${fat32_root_dir}"
 
-	# Show the state
-	du -h -d 1 "${bootable_base_dir}"
-	tree "${bootable_base_dir}"
-
 	# Use a Dockerfile to assemble a GPT image, with a single FAT32 partition, containing the files in the fat32-root directory
 	# This is common across all GPT-based bootable media; the only difference is the ESP flag, which is set for UEFI bootable media but not for Rockchip/RaspberryPi
 	# The u-boot binaries are written _later_ in the process, after the image is created, using Armbian's helper scripts.
 	create_image_fat32_root_from_dir "${bootable_base_dir}" "bootable-media-rpi.img" "${bootable_dir}/fat32-root"
-
-	log info "Show info about produced image..."
-	ls -lah "${bootable_base_dir}/bootable-media-rpi.img"
 
 	log info "Done building rpi bootable for hook ${hook_id}"
 	output_bootable_media "${bootable_base_dir}/bootable-media-rpi.img" "hook-bootable-rpi.img"
@@ -129,6 +122,8 @@ function rpi_write_config_txt() {
 		initramfs initrd.img followkernel
 		arm_64bit=1
 	RPI_CONFIG_TXT
+
+	bat_language="ini" log_file_bat "${fat32_root_dir}/config.txt" "info" "Produced rpi config.txt"
 }
 
 function rpi_write_cmdline_txt() {
@@ -140,4 +135,6 @@ function rpi_write_cmdline_txt() {
 	cat <<- RPI_CMDLINE_TXT > "${fat32_root_dir}/cmdline.txt"
 		console=tty1 console=ttyAMA0,115200 loglevel=7 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory ${tinkerbell_args}
 	RPI_CMDLINE_TXT
+
+	log_file_bat "${fat32_root_dir}/cmdline.txt" "info" "Produced rpi cmdline.txt"
 }

--- a/bash/bootable/rpi.sh
+++ b/bash/bootable/rpi.sh
@@ -110,11 +110,10 @@ function rpi_write_config_txt() {
 	declare fat32_root_dir="${1}"
 	cat <<- RPI_CONFIG_TXT > "${fat32_root_dir}/config.txt"
 		# For more options and information see http://rptl.io/configtxt
-		# Automatically load initramfs files, if found
 		auto_initramfs=1
 		# bootloader logs to serial, second stage
 		enable_uart=1
-		# if uart is enabled, disable Bluetooth which also uses UART
+		# disable Bluetooth, as having it enabled causes issues with the serial console due to fake Broadcom UART
 		dtoverlay=disable-bt
 		dtoverlay=vc4-kms-v3d
 		max_framebuffers=2

--- a/bash/common.sh
+++ b/bash/common.sh
@@ -34,6 +34,25 @@ function log_tree() {
 	fi
 }
 
+# Helper for showing the contents of a file (using bat, if installed)
+function log_file_bat() {
+	declare file="${1}"
+	shift
+	declare level="${1}"
+	shift
+	[[ "${level}" == "debug" && "${DEBUG}" != "yes" ]] && return # Skip debugs unless DEBUG=yes is set in the environment
+	log "${level}" "${@}" "-- file ${file}:"
+	declare extra_bat_args=()
+	if [[ -n "${bat_language}" ]]; then
+		extra_bat_args+=("--language=${bat_language}")
+	fi
+	if command -v bat > /dev/null; then
+		bat --color=always "${extra_bat_args[@]}" "${file}"
+	else
+		log "${level}" "'bat' utility not installed; install it to see file contents in logs."
+	fi
+}
+
 function install_dependencies() {
 	declare extra="${1}"
 

--- a/bash/linuxkit.sh
+++ b/bash/linuxkit.sh
@@ -153,14 +153,14 @@ function linuxkit_build() {
 	fi
 
 	# rename outputs
-	mv -v "${lk_output_dir}/hook-kernel" "${lk_output_dir}/vmlinuz-${OUTPUT_ID}"
-	mv -v "${lk_output_dir}/hook-initrd.img" "${lk_output_dir}/initramfs-${OUTPUT_ID}"
+	mv "${debug_dash_v[@]}" "${lk_output_dir}/hook-kernel" "${lk_output_dir}/vmlinuz-${OUTPUT_ID}"
+	mv "${debug_dash_v[@]}" "${lk_output_dir}/hook-initrd.img" "${lk_output_dir}/initramfs-${OUTPUT_ID}"
 	rm "${lk_output_dir}/hook-cmdline"
 
 	# prepare out/hook dir with the kernel/initramfs pairs; this makes it easy to deploy to /opt/hook eg for stack chart (or nibs)
 	mkdir -p "out/hook"
-	mv -v "${lk_output_dir}/vmlinuz-${OUTPUT_ID}" "out/hook/vmlinuz-${OUTPUT_ID}"
-	mv -v "${lk_output_dir}/initramfs-${OUTPUT_ID}" "out/hook/initramfs-${OUTPUT_ID}"
+	mv "${debug_dash_v[@]}" "${lk_output_dir}/vmlinuz-${OUTPUT_ID}" "out/hook/vmlinuz-${OUTPUT_ID}"
+	mv "${debug_dash_v[@]}" "${lk_output_dir}/initramfs-${OUTPUT_ID}" "out/hook/initramfs-${OUTPUT_ID}"
 
 	declare -a output_files=("vmlinuz-${OUTPUT_ID}" "initramfs-${OUTPUT_ID}")
 
@@ -192,8 +192,8 @@ function linuxkit_build() {
 
 	if [[ "${OUTPUT_TARBALL_FILELIST:-"no"}" == "yes" ]]; then
 		log info "OUTPUT_TARBALL_FILELIST=yes; including tar and filelist in output."
-		mv -v "${lk_output_dir}/hook.tar" "out/hook/hook_rootfs_${OUTPUT_ID}.tar"
-		tar --list -vf "out/hook/hook_rootfs_${OUTPUT_ID}.tar" > "out/hook/hook_rootfs_${OUTPUT_ID}.filelist"
+		mv "${debug_dash_v[@]}" "${lk_output_dir}/hook.tar" "out/hook/hook_rootfs_${OUTPUT_ID}.tar"
+		tar --list -f "${debug_dash_v[@]}" "out/hook/hook_rootfs_${OUTPUT_ID}.tar" > "out/hook/hook_rootfs_${OUTPUT_ID}.filelist"
 	fi
 
 	# finally clean up the hook-specific out dir
@@ -201,7 +201,7 @@ function linuxkit_build() {
 
 	# tar the files into out/hook.tar in such a way that vmlinuz and initramfs are at the root of the tar; pigz it
 	# Those are the artifacts published to the GitHub release
-	tar -cvf- -C "out/hook" "${output_files[@]}" | pigz > "out/hook_${OUTPUT_ID}.tar.gz"
+	tar "${debug_dash_v[@]}" -cf- -C "out/hook" "${output_files[@]}" | pigz > "out/hook_${OUTPUT_ID}.tar.gz"
 }
 
 function linuxkit_run_qemu() {

--- a/build.sh
+++ b/build.sh
@@ -27,6 +27,12 @@ declare -a -g CLI_NON_PARAM_ARGS=()
 parse_command_line_arguments "${@}" # which fills the above vars & exports the key=value pairs from cmdline into environment
 # From here on, no more $1 ${1} or similar. We've parsed it all into CLI_PARSED_CMDLINE_PARAMS (already exported in environment) or CLI_NON_PARAM_ARGS
 
+## Global debug helpers; to use for coreutils mv/cp/etc; usage: mv "${debug_dash_v[@]}" here there
+declare -g -a debug_dash_v=()
+if [[ "${DEBUG}" == "yes" ]]; then
+	debug_dash_v+=("-v")
+fi
+
 ### Configuration
 declare -g HOOK_KERNEL_OCI_BASE="${HOOK_KERNEL_OCI_BASE:-"quay.io/tinkerbell/hook-kernel"}"
 declare -g HOOK_LK_CONTAINERS_OCI_BASE="${HOOK_LK_CONTAINERS_OCI_BASE:-"quay.io/tinkerbell/"}"


### PR DESCRIPTION
> Some logging cleanup. 
> Take env/params and consistently add them to all bootloader configs (grub.cfg / extlinux.conf / boot.scr / cmdline.txt); vars should be consistent with the qemu-run invocation
> No, there is _still_ no `README.txt` generation in here. Coming up.
> No, no CI changes yet. This is all focused on building bootable images manually, for now.

#### bootable: cleanup logging; use bat/tree helpers


#### bootable: rpi: cleanup config.txt


#### bootable: rpi: cmdline.txt: handle tink-related kernel args

- using `fill_array_bootable_tinkerbell_kernel_parameters()`


#### bootable: grub: grub.cfg: handle tink-related kernel args

- using `fill_array_bootable_tinkerbell_kernel_parameters()`


#### bootable: u-boot: extlinux/boot.scr: handle tink-related kernel args

- using `fill_array_bootable_tinkerbell_kernel_parameters()`


#### linuxkit: cleanup debug logging


#### bootable: introduce `fill_array_bootable_tinkerbell_kernel_parameters()`

- this reads variables and produces kernel command line for all bootables
- it defaults to a bare `tinkerbell` hostname, but that can be overridden
  with `TINK_SERVER` var/param
  - `grpc_authority=tinkerbell:42113`
  - `syslog_host=tinkerbell`


#### build: global debug helpers for coreutils mv/cp/etc

- usage: `mv "${debug_dash_v[@]}" here there`


#### common: add helper `log_file_bat()`

- so I don't keep spreading conditionals everywhere


#### bootable: add required argument handling


#### bootable: rockchip: add quartz64a board (Armbian edge kernel)


