### PR TITLE
hook-bootkit: fix: last kernel cmdline option would have a newline

### DIFF
--- a/images/hook-bootkit/main.go
+++ b/images/hook-bootkit/main.go
@@ -263,7 +263,7 @@ func removeTinkWorkerContainer(ctx context.Context, cli *client.Client) error {
 // https://github.com/tinkerbell/boots/blob/main/ipxe/hook.go
 func parseCmdLine(cmdLines []string) (cfg tinkWorkerConfig) {
 	for i := range cmdLines {
-		cmdLine := strings.SplitN(cmdLines[i], "=", 2)
+		cmdLine := strings.SplitN(strings.TrimSpace(cmdLines[i]), "=", 2)
 		if len(cmdLine) == 0 {
 			continue
 		}


### PR DESCRIPTION
Similar to #262 but for hook-bootkit.