### PR TITLE
udev: run both as onboot and as service; drop hardcoded modprobe

### DIFF
--- a/images/hook-udev/Dockerfile
+++ b/images/hook-udev/Dockerfile
@@ -6,4 +6,5 @@ RUN DEBIAN_FRONTEND=noninteractive apt update && \
     apt-get autoremove --yes && \
     rm -rf /var/lib/apt /var/lib/dpkg /var/lib/cache /var/lib/log /var/cache/* /usr/lib/apt/* /usr/share/*
 
-CMD ["/etc/init.d/udev", "start"]
+ADD ./one-shot.sh /one-shot.sh
+CMD ["/lib/systemd/systemd-udevd", "--debug"]

--- a/images/hook-udev/one-shot.sh
+++ b/images/hook-udev/one-shot.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/bash
+
+# Here we start the systemd-udev daemon, sleep a bit, run udevadm settle, and then stop the daemon, all using bash.
+# This is a one-shot script that is run by LinuxKit when the system boots up.
+
+echo "$(date) Starting systemd-udev in the background..."
+/lib/systemd/systemd-udevd "${@}" &
+declare udev_pid=$!
+echo "$(date) systemd-udev started with PID: ${udev_pid}"
+
+echo "$(date) Sleeping for 2 seconds so systemd-udev does its job..."
+sleep 2
+
+echo "$(date) Running udevadm trigger..."
+udevadm trigger --action=add
+
+echo "$(date) Running udevadm settle..."
+udevadm settle
+
+echo "$(date) Status of /dev/disk/by-id:"
+ls -la /dev/disk/by-id/* || true
+
+echo "$(date) Stopping systemd-udev with PID: ${udev_pid}"
+kill -SIGTERM "${udev_pid}"
+
+echo "$(date) Waiting for systemd-udev to stop..."
+wait
+
+echo "$(date) systemd-udev stopped with PID: ${udev_pid}"
+echo "$(date) One-shot script completed."
+
+exit 0

--- a/linuxkit-templates/hook.template.yaml
+++ b/linuxkit-templates/hook.template.yaml
@@ -37,22 +37,13 @@ onboot:
   - name: sysfs
     image: linuxkit/sysfs:v1.0.0
 
-  - name: modprobe
-    image: linuxkit/modprobe:v1.0.0
-    command: [ "modprobe", "cdc_ncm" ] # for usb ethernet dongles
-
-  - name: udev
+  - name: udev-once
     image: "${HOOK_CONTAINER_UDEV_IMAGE}"
-    capabilities:
-      - all
-    binds:
-      - /dev:/dev
-      - /sys:/sys
-      - /lib/modules:/lib/modules
+    command: [ "/usr/bin/bash", "/one-shot.sh" ]
+    capabilities: [ all ]
+    binds: [ /dev:/dev, /sys:/sys, /lib/modules:/lib/modules ]
     rootfsPropagation: shared
-    devices:
-      - path: all
-        type: b
+    devices: [ { path: all, type: b },  { path: all, type: c } ]
 
   - name: dhcpcd-once
     image: linuxkit/dhcpcd:v1.0.0
@@ -76,6 +67,14 @@ services:
 
   - name: ntpd
     image: linuxkit/openntpd:v1.0.0
+
+  - name: udev # as a service; so system reacts to changes in devices
+    image: "${HOOK_CONTAINER_UDEV_IMAGE}"
+    command: [ "/lib/systemd/systemd-udevd", "--debug" ]
+    capabilities: [ all ]
+    binds: [ /dev:/dev, /sys:/sys, /lib/modules:/lib/modules ]
+    rootfsPropagation: shared
+    devices: [ { path: all, type: b },  { path: all, type: c } ]
 
   - name: getty
     image: linuxkit/getty:v1.0.0


### PR DESCRIPTION
#### udev: run both as onboot and as service; drop hardcoded modprobe

- udev onboot is required so all devices are setup before the rest runs
  - hackish 'one-shot.sh' starts udev, waits until its done, then kills it
- udev service is required so changes to devices (eg partition changes)
  take actual effect at runtime
- systemd's udev should correctly modprobe all devices, thus remove the
  hardcoded modprobe call for cdc_ncm

Signed-off-by: Ricardo Pardini <ricardo@pardini.net>