### PR TITLE
Update linuxkit version; Add Host filesystem to hook-docker

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -40,7 +40,7 @@ declare -g HOOK_LK_CONTAINERS_OCI_BASE="${HOOK_LK_CONTAINERS_OCI_BASE:-"quay.io/
 declare -g SKOPEO_IMAGE="${SKOPEO_IMAGE:-"quay.io/skopeo/stable:v1.17.0"}" # See https://quay.io/repository/skopeo/stable?tab=tags&tag=latest
 
 # See https://github.com/linuxkit/linuxkit/releases
-declare -g -r LINUXKIT_VERSION_DEFAULT="1.5.3" # LinuxKit version to use by default; each flavor can set its own too
+declare -g -r LINUXKIT_VERSION_DEFAULT="${LINUXKIT_VERSION:-"1.6.0"}" # LinuxKit version to use by default; each flavor can set its own too
 
 # Directory to use for storing downloaded artifacts: LinuxKit binary, shellcheck binary, etc.
 declare -g -r CACHE_DIR="${CACHE_DIR:-"cache"}"

--- a/linuxkit-templates/hook.template.yaml
+++ b/linuxkit-templates/hook.template.yaml
@@ -176,6 +176,7 @@ services:
       - /var/run/docker:/var/run
       - /var/run/images:/var/lib/docker
       - /var/run/worker:/worker
+      - /:/host_root
     runtime:
       mkdir:
         - /var/run/images


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
`linuxkit` 1.6.0 is available for use. This has at least one useful feature related to ISO building that is needed. Also, make the linuxkit version configurable.

Add Host filesystem mount to hook-docker. This is helpful for Action images that might
need access to root Host filesystem locations. For example, when using https://github.com/jaypipes/ghw in an Action. ghw needs access to udev data that only exists in the Host filesystem.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
