### PR TITLE
Add acpid service:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ images/hook-embedded/docker/*
 !images/hook-embedded/docker/.keep
 images/hook-embedded/images_tar/*
 !images/hook-embedded/images_tar/.keep
+scratch/

--- a/bash/hook-lk-containers.sh
+++ b/bash/hook-lk-containers.sh
@@ -10,6 +10,7 @@ function build_all_hook_linuxkit_containers() {
 	build_hook_linuxkit_container hook-bootkit "HOOK_CONTAINER_BOOTKIT_IMAGE"
 	build_hook_linuxkit_container hook-docker "HOOK_CONTAINER_DOCKER_IMAGE"
 	build_hook_linuxkit_container hook-udev "HOOK_CONTAINER_UDEV_IMAGE"
+	build_hook_linuxkit_container hook-acpid "HOOK_CONTAINER_ACPID_IMAGE"
 	build_hook_linuxkit_container hook-containerd "HOOK_CONTAINER_CONTAINERD_IMAGE"
 	build_hook_linuxkit_container hook-runc "HOOK_CONTAINER_RUNC_IMAGE"
 	build_hook_linuxkit_container hook-embedded "HOOK_CONTAINER_EMBEDDED_IMAGE"

--- a/images/hook-acpid/Dockerfile
+++ b/images/hook-acpid/Dockerfile
@@ -1,0 +1,61 @@
+# We are building a static acpid binary from source because the linuxkit/acpid image
+# does not work 
+FROM alpine:3.22 AS alpine
+
+# Install build dependencies
+RUN apk add --no-cache \
+    gcc \
+    musl-dev \
+    make \
+    git \
+    autoconf \
+    automake \
+    libtool \
+    linux-headers \
+    wget \
+    xz \
+    patch \
+    busybox-static \
+    # Install the dynamically built acpid so that we can get the handler script and event files
+    acpid
+
+# Download and build acpid
+ENV ACPID_VERSION=2.0.34
+RUN wget https://sourceforge.net/projects/acpid2/files/acpid-${ACPID_VERSION}.tar.xz/download -O acpid-${ACPID_VERSION}.tar.xz && \
+    tar -xf acpid-${ACPID_VERSION}.tar.xz
+
+WORKDIR /acpid-${ACPID_VERSION}
+
+# Fix musl compatibility - replace stat64/fstat64 with stat/fstat
+RUN sed -i 's/struct stat64/struct stat/g' sock.c && \
+    sed -i 's/fstat64/fstat/g' sock.c
+
+# Build static binary with musl-compatible flags
+RUN ./configure \
+    --enable-static \
+    --disable-shared \
+    CFLAGS="-D_GNU_SOURCE -Os" \
+    LDFLAGS="-static" && \
+    make && \
+    strip acpid && \
+    cp acpid /usr/bin/
+
+# Verify it's statically linked
+RUN ldd /usr/bin/acpid 2>&1 | grep -q "not a dynamic executable" || echo "Warning: not statically linked"
+
+# Copy BusyBox static binary and create poweroff symlink
+RUN mkdir -p /stage/bin && cp /bin/busybox.static /bin/busybox && \
+    ln -s /bin/busybox /stage/bin/poweroff && \
+    ln -s /bin/busybox /stage/bin/logger && \
+    # This is needed for the acpid handler scripts (/etc/acpi/handler.sh, /etc/acpi/events/anything) to work
+    ln -s /bin/busybox /stage/bin/sh
+
+FROM scratch
+WORKDIR /
+ENTRYPOINT []
+COPY --from=alpine /usr/bin/acpid /usr/bin/
+COPY --from=alpine /etc/acpi/events/anything /etc/acpi/events/anything
+COPY --from=alpine /etc/acpi/handler.sh /etc/acpi/handler.sh
+COPY --from=alpine /bin/busybox /bin/busybox
+COPY --from=alpine /stage/ /
+CMD ["/usr/bin/acpid", "-f", "-d"]

--- a/linuxkit-templates/hook.template.yaml
+++ b/linuxkit-templates/hook.template.yaml
@@ -6,6 +6,7 @@
 # - HOOK_CONTAINER_BOOTKIT_IMAGE: ${HOOK_CONTAINER_BOOTKIT_IMAGE}
 # - HOOK_CONTAINER_DOCKER_IMAGE: ${HOOK_CONTAINER_DOCKER_IMAGE}
 # - HOOK_CONTAINER_UDEV_IMAGE: ${HOOK_CONTAINER_UDEV_IMAGE}
+# - HOOK_CONTAINER_ACPID_IMAGE: ${HOOK_CONTAINER_ACPID_IMAGE}
 # - HOOK_CONTAINER_CONTAINERD_IMAGE: ${HOOK_CONTAINER_CONTAINERD_IMAGE}
 # - HOOK_CONTAINER_RUNC_IMAGE: ${HOOK_CONTAINER_RUNC_IMAGE}
 # - HOOK_CONTAINER_EMBEDDED_IMAGE: ${HOOK_CONTAINER_EMBEDDED_IMAGE}
@@ -77,6 +78,20 @@ services:
 
   - name: ntpd
     image: linuxkit/openntpd:v1.0.0
+
+  - name: acpi
+    image: "${HOOK_CONTAINER_ACPID_IMAGE}"
+    capabilities:
+      - all
+    pid: host
+    binds.add:
+      - /dev:/dev
+      - /var/run:/var/run
+    devices:
+      - path: all
+        type: b
+      - path: all
+        type: c
 
   - name: getty
     image: linuxkit/getty:v1.0.0


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This service allows HookOS to react to ACPI events. Useful for things like `ipmitool chassis power soft`.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
