### PR TITLE
Add udev as a service:

### DIFF
--- a/linuxkit-templates/hook.template.yaml
+++ b/linuxkit-templates/hook.template.yaml
@@ -79,6 +79,20 @@ services:
   - name: ntpd
     image: linuxkit/openntpd:v1.0.0
 
+  - name: udev # as a service; so system reacts to changes in devices
+    image: "${HOOK_CONTAINER_UDEV_IMAGE}"
+    command: [ "/lib/systemd/systemd-udevd", "--debug" ]
+    capabilities: [ all ]
+    binds: [ /dev:/dev, /sys:/sys, /lib/modules:/lib/modules ]
+    rootfsPropagation: shared
+    net: host
+    pid: host
+    devices:
+      - path: all
+        type: b
+      - path: all
+        type: c
+
   - name: acpi
     image: "${HOOK_CONTAINER_ACPID_IMAGE}"
     capabilities:


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->

This allows devices to be updated when there are changes during the runtime of HookOS.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
