### PR TITLE
Use find -print0 and xargs -0 to fix file hashing

### DIFF
--- a/bash/hook-lk-containers.sh
+++ b/bash/hook-lk-containers.sh
@@ -24,7 +24,7 @@ function build_hook_linuxkit_container() {
 	# Lets hash the contents of the directory and use that as a tag
 	declare container_files_hash
 	# NOTE: linuxkit containers must be in the images/ directory
-	container_files_hash="$(find "${container_base_dir}/${container_dir}" -type f -print | LC_ALL=C sort | xargs sha256sum | sha256sum | cut -d' ' -f1)"
+	container_files_hash="$(find "${container_base_dir}/${container_dir}" -type f -print0 | LC_ALL=C sort -z | xargs -0 sha256sum | sha256sum | cut -d' ' -f1)"
 	declare container_files_hash_short="${container_files_hash:0:8}"
 
 	declare container_oci_ref="${HOOK_LK_CONTAINERS_OCI_BASE}${container_dir}:${container_files_hash_short}-${DOCKER_ARCH}"


### PR DESCRIPTION
Example:
```
++ find images/hook-embedded -type f -not -type l -print
++ LC_ALL=C
++ sort
++ xargs sha256sum
++ sha256sum
++ cut '-d ' -f1
sha256sum: images/hook-embedded/images/overlay2/4f2b976a728e2f978ec5a0728e7a7de5ac8e86d05424567038829628a23a0787/diff/nix/store/q94x70qac6cnly6w60mlgfkaa8npk9xw-systemd-257.5/example/systemd/system/system-systemdx2dcryptsetup.slice: No such file or directory
```

File enumeration should use a null-terminated approach that safely preserves file names regardless of any whitespace or special characters.

`-print0` and `-0` Options: These ensure file names are treated as complete, atomic strings.
`LC_ALL=C sort -z`: This guarantees a consistent, bytewise sort order while preserving the null termination.

Fixes: #260 