### PR TITLE
Bump version:

### DIFF
--- a/.github/workflows/build-all-matrix.yaml
+++ b/.github/workflows/build-all-matrix.yaml
@@ -19,7 +19,7 @@ env: # Global environment, passed to all jobs & all steps
   # To do so, set the secret DOCKERHUB_USERNAME and DOCKERHUB_PASSWORD in the repo secrets, and set the below to yes.
   LOGIN_TO_DOCKERHUB: "yes"
   
-  HOOK_VERSION: "0.10.0-build-${{github.run_number}}" # Use a forced Hook version
+  HOOK_VERSION: "0.11.1-build-${{github.run_number}}" # Use a forced Hook version
   
   # Which flavors to build? space separated list, must match one of the TAG='s in flavors (this is used by matrix_prep job in gha-matrix command)
   CI_TAGS: "standard armbian-sbc armbian-uefi lts" # 'dev' is not included

--- a/build.sh
+++ b/build.sh
@@ -54,7 +54,7 @@ else # otherwise default to tty, but allow override
 fi
 
 # Set the default HOOK_VERSION; override with env var; -x exports it for envsubst later
-declare -g -r -x HOOK_VERSION="${HOOK_VERSION:-"0.10.0"}"
+declare -g -r -x HOOK_VERSION="${HOOK_VERSION:-"0.11.1"}"
 log info "Using Hook version (HOOK_VERSION): ${HOOK_VERSION}"
 
 ### Inventory


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
The v0.11.0 release did not have the version updated. This bumps to v0.11.1 in preparation for a new tagged release.
Because the version was not bumped in the v0.11.0 tag, HookOS is still showing v0.10.0 when booting up.
## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
