### PR TITLE
Fix kernel builds; Migrate ci runners

### DIFF
--- a/.github/workflows/build-all-matrix.yaml
+++ b/.github/workflows/build-all-matrix.yaml
@@ -25,10 +25,10 @@ env: # Global environment, passed to all jobs & all steps
   CI_TAGS: "standard armbian-sbc armbian-uefi lts" # 'dev' is not included
   
   # GHA runner configuration. See bash/json-matrix.sh for more details.
-  CI_RUNNER_LK_CONTAINERS_ARM64: "oracle-24cpu-384gb-arm64" # Use a self-hosted runner with the "ARM64" tag for the ARM64 builds of LK containers
-  CI_RUNNER_LK_CONTAINERS_AMD64: "oracle-24cpu-384gb-x86-64" # Use a self-hosted runner with the "X86" tag for the AMD64 builds of LK containers
-  CI_RUNNER_LK_ARM64: "oracle-24cpu-384gb-arm64" # Use a self-hosted runner with the "ARM64" tag for the ARM64 linuxkit builds
-  CI_RUNNER_LK_AMD64: "oracle-24cpu-384gb-x86-64" # Use a self-hosted runner with the "X86" tag for the AMD64 linuxkit builds
+  CI_RUNNER_LK_CONTAINERS_ARM64: "oracle-vm-32cpu-128gb-arm64" # Use a self-hosted runner with the "ARM64" tag for the ARM64 builds of LK containers
+  CI_RUNNER_LK_CONTAINERS_AMD64: "oracle-vm-32cpu-128gb-x86-64" # Use a self-hosted runner with the "X86" tag for the AMD64 builds of LK containers
+  CI_RUNNER_LK_ARM64: "oracle-vm-32cpu-128gb-arm64" # Use a self-hosted runner with the "ARM64" tag for the ARM64 linuxkit builds
+  CI_RUNNER_LK_AMD64: "oracle-vm-32cpu-128gb-x86-64" # Use a self-hosted runner with the "X86" tag for the AMD64 linuxkit builds
   CI_RUNNER_KERNEL_AMD64: "oracle-24cpu-384gb-x86-64" # Use a self-hosted runner with the "X86" tag for the AMD64 kernel builds
   CI_RUNNER_KERNEL_ARM64: "oracle-24cpu-384gb-arm64" # Use a self-hosted runner with the "ARM64" tag for the ARM64 kernel builds
 
@@ -60,7 +60,9 @@ jobs:
   
   build-linuxkit-containers:
     needs: [ matrix_prep ]
-    runs-on: "${{ matrix.runner }}" # the runner to use is determined by the 'gha-matrix' code
+    runs-on:
+      group: Default
+      labels: "${{ matrix.runner }}" # the runner to use is determined by the 'gha-matrix' code
     strategy:
       fail-fast: true
       matrix:
@@ -75,6 +77,10 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["mirror.gcr.io"]
 
       - name: Docker Login to quay.io
         if: ${{ env.REGISTRY == 'quay.io' && github.ref == 'refs/heads/main' }}
@@ -86,15 +92,26 @@ jobs:
         uses: docker/login-action@v3
         with: { registry: "ghcr.io", username: "${{ github.repository_owner }}", password: "${{ secrets.GITHUB_TOKEN }}" }
 
-      - name: Build and Push LinuxKit containers for ${{matrix.docker_arch}}
+      - name: Build and Push and Export LinuxKit containers for ${{matrix.docker_arch}}
         env:
           DOCKER_ARCH: "${{ matrix.docker_arch }}"
           DO_PUSH: "${{ github.ref == 'refs/heads/main' && 'yes' || 'no' }}"
+          EXPORT_LK_CONTAINERS: "yes"
+          EXPORT_LK_CONTAINERS_DIR: "${{ runner.temp }}"
         run: bash build.sh linuxkit-containers
-  
+
+      - name: Upload Linuxkit Docker images as GitHub Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: linuxkit-images-${{ matrix.docker_arch }}
+          path: ${{ runner.temp }}/*-${{ matrix.docker_arch }}.tar.gz
+          retention-days: 1
+
   build-kernels:
     needs: [ matrix_prep ] # depend on the previous job...
-    runs-on: "${{ matrix.runner }}" # the runner to use is determined by the 'gha-matrix' code
+    runs-on:
+      group: Default
+      labels: "${{ matrix.runner }}" # the runner to use is determined by the 'gha-matrix' code
     strategy:
       fail-fast: false # let other jobs try to complete if one fails, kernels might take long, and they'd be skipped on the next run
       matrix:
@@ -106,6 +123,10 @@ jobs:
 
       - name: Set up Docker Buildx # nb: no need for qemu here, kernels are cross-compiled, instead of the compilation being emulated
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["mirror.gcr.io"]
 
       - name: Docker Login to quay.io
         if: ${{ env.REGISTRY == 'quay.io' && github.ref == 'refs/heads/main' }}
@@ -120,11 +141,22 @@ jobs:
       - name: Build and push Kernel ${{matrix.kernel}} (${{ matrix.arch }})
         env:
           DO_PUSH: "${{ github.ref == 'refs/heads/main' && 'yes' || 'no' }}"
+          EXPORT_KERNEL_IMAGE: "yes"
+          EXPORT_KERNEL_IMAGE_DIR: "${{ runner.temp }}"
         run: bash build.sh build-kernel "${{ matrix.kernel }}"
+
+      - name: Upload Kernel Docker images as GitHub Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: kernel-images-${{ matrix.kernel }}
+          path: ${{ runner.temp }}/hook-kernel-*.tar.gz
+          retention-days: 1
 
   build-hook-ensemble:
     needs: [ matrix_prep, build-linuxkit-containers, build-kernels ] # depend on the previous job...
-    runs-on: "${{ matrix.runner }}" # the runner to use is determined by the 'gha-matrix' code
+    runs-on:
+      group: Default
+      labels: "${{ matrix.runner }}" # the runner to use is determined by the 'gha-matrix' code
     strategy:
       fail-fast: false # let other jobs try to complete if one fails
       matrix:
@@ -136,6 +168,10 @@ jobs:
 
       - name: Set up Docker Buildx # nb: no need for qemu here, kernels are cross-compiled, instead of the compilation being emulated
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["mirror.gcr.io"]
 
       - name: Docker Login to DockerHub # read-only token, required to be able to pull all the linuxkit pkgs without getting rate limited.
         if: ${{ env.LOGIN_TO_DOCKERHUB == 'yes' && github.ref == 'refs/heads/main' }}
@@ -163,6 +199,42 @@ jobs:
             lk-cache-${{ matrix.docker_arch }}
           save-always: true # always save the cache, even if build fails
 
+      - name: Download Linuxkit artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: linuxkit-images-${{ matrix.docker_arch }}
+          path: ${{ runner.temp }}
+
+      - name: Load Linuxkit Docker images into local Docker daemon
+        run: |
+          ls "${{ runner.temp }}"
+          imgs=$(ls "${{ runner.temp }}" | grep tar.gz | xargs)
+          echo "Found hook images: ${imgs}"
+          for img in ${imgs}; do
+            echo "extracting and loading image: ${{ runner.temp }}/${img}"
+            gunzip -d "${{ runner.temp }}/${img}"
+            docker load --input "${{ runner.temp }}/${img%.*}"
+          done
+          docker images
+
+      - name: Download Kernel artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: kernel-images-${{ matrix.kernel }}
+          path: ${{ runner.temp }}
+
+      - name: Load Kernel Docker images into local Docker daemon
+        run: |
+          ls "${{ runner.temp }}"
+          imgs=$(ls "${{ runner.temp }}" | grep tar.gz | xargs)
+          echo "Found kernel images: ${{ runner.temp }}/${imgs}"
+          for img in ${imgs}; do
+            echo "extracting and loading image: ${{ runner.temp }}/${img}"
+            gunzip -d "${{ runner.temp }}/${img}"
+            docker load --input "${{ runner.temp }}/${img%.*}"
+          done
+          docker images
+
       - name: "Build Hook with Kernel ${{matrix.kernel}} (${{ matrix.arch }}) - cache: ${{matrix.gha_cache}}"
         env:
           DO_BUILD_LK_CONTAINERS: "no" # already built them; this is only for hook/linuxkit.
@@ -181,6 +253,7 @@ jobs:
           path: |
             out/*.tar.gz
             out/*.iso
+          retention-days: 1
 
   release-latest:
     name: Publish all Hooks to GitHub Releases

--- a/.github/workflows/build-all-matrix.yaml
+++ b/.github/workflows/build-all-matrix.yaml
@@ -96,7 +96,7 @@ jobs:
         env:
           DOCKER_ARCH: "${{ matrix.docker_arch }}"
           DO_PUSH: "${{ github.ref == 'refs/heads/main' && 'yes' || 'no' }}"
-          EXPORT_LK_CONTAINERS: "yes"
+          EXPORT_LK_CONTAINERS: "${{ github.event_name == 'pull_request' && 'yes' || 'no' }}" # Builds on PRs don't push images to a registry so they need to be passed on through GitHub Artifacts.
           EXPORT_LK_CONTAINERS_DIR: "${{ runner.temp }}"
         run: bash build.sh linuxkit-containers
 
@@ -138,10 +138,10 @@ jobs:
         uses: docker/login-action@v3
         with: { registry: "ghcr.io", username: "${{ github.repository_owner }}", password: "${{ secrets.GITHUB_TOKEN }}" }
 
-      - name: Build and push Kernel ${{matrix.kernel}} (${{ matrix.arch }})
+      - name: Build and Push and Export Kernel ${{matrix.kernel}} (${{ matrix.arch }})
         env:
           DO_PUSH: "${{ github.ref == 'refs/heads/main' && 'yes' || 'no' }}"
-          EXPORT_KERNEL_IMAGE: "yes"
+          EXPORT_KERNEL_IMAGE: "${{ github.event_name == 'pull_request' && 'yes' || 'no' }}" # Builds on PRs don't push images to a registry so they need to be passed on through GitHub Artifacts.
           EXPORT_KERNEL_IMAGE_DIR: "${{ runner.temp }}"
         run: bash build.sh build-kernel "${{ matrix.kernel }}"
 

--- a/.github/workflows/build-all-matrix.yaml
+++ b/.github/workflows/build-all-matrix.yaml
@@ -45,7 +45,7 @@ jobs:
       lk_hooks_json: ${{ steps.prepare-matrix.outputs.lk_hooks_json }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Prepare release ID (current date) # This only used for the GitHub Release; not included in any way in the build process.
         id: date_prep
@@ -70,7 +70,7 @@ jobs:
     name: "LinuxKit containers for ${{ matrix.docker_arch }}"
     steps:
       - name: Checkout build repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -119,7 +119,7 @@ jobs:
     name: "Kernel ${{ matrix.kernel }}"
     steps:
       - name: Checkout build repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx # nb: no need for qemu here, kernels are cross-compiled, instead of the compilation being emulated
         uses: docker/setup-buildx-action@v3
@@ -164,7 +164,7 @@ jobs:
     name: "Hook ${{ matrix.kernel }}"
     steps:
       - name: Checkout build repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx # nb: no need for qemu here, kernels are cross-compiled, instead of the compilation being emulated
         uses: docker/setup-buildx-action@v3
@@ -200,7 +200,7 @@ jobs:
           save-always: true # always save the cache, even if build fails
 
       - name: Download Linuxkit artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: linuxkit-images-${{ matrix.docker_arch }}
           path: ${{ runner.temp }}
@@ -218,7 +218,7 @@ jobs:
           docker images
 
       - name: Download Kernel artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: kernel-images-${{ matrix.kernel }}
           path: ${{ runner.temp }}
@@ -263,10 +263,10 @@ jobs:
     steps:
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download built Hook artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: "hook-tarball-*"
           merge-multiple: true
@@ -335,10 +335,10 @@ jobs:
     steps:
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download built Hook artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: "hook-tarball-*"
           merge-multiple: true

--- a/bash/json-matrix.sh
+++ b/bash/json-matrix.sh
@@ -210,9 +210,6 @@ function json_matrix_find_runner() {
 	declare -a json_items_bare=(${runner})
 	# wrap each json_items array item in double quotes
 	declare -a json_items=()
-	if [[ "${runner}" != "ubuntu-latest" ]]; then # if not using a GH-hosted runner, auto-add the "self-hosted" member
-		json_items+=("\"self-hosted\"")
-	fi
 	for item in "${json_items_bare[@]}"; do
 		json_items+=("\"${item}\"")
 	done

--- a/bash/kernel.sh
+++ b/bash/kernel.sh
@@ -48,6 +48,11 @@ function kernel_build() {
 	else
 		log info "DO_PUSH not 'yes', not pushing."
 	fi
+
+	if [[ "${EXPORT_KERNEL_IMAGE}" == "yes" ]]; then
+		log info "Exporting kernel image ${kernel_oci_image} to ${EXPORT_KERNEL_IMAGE_DIR}"
+		save_docker_image_to_tar_gz "${kernel_oci_image}" "${EXPORT_KERNEL_IMAGE_DIR}"
+	fi
 }
 
 function kernel_configure_interactive() {

--- a/kernel/Dockerfile
+++ b/kernel/Dockerfile
@@ -3,7 +3,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # crossbuild-essentials are pretty heavy; here we install for both architecures to maximize Docker layer hit cache rate during development, but only one will be used
 RUN set -x && apt -o "Dpkg::Use-Pty=0" -y update && \
-      apt -o "Dpkg::Use-Pty=0" -y install curl xz-utils gnupg2 flex bison libssl-dev libelf-dev bc libncurses-dev kmod \
+      apt -o "Dpkg::Use-Pty=0" -y install curl xz-utils gnupg2 flex bison libssl-dev libelf-dev bc libncurses-dev kmod make \
                      crossbuild-essential-amd64 crossbuild-essential-arm64 && \
       apt -o "Dpkg::Use-Pty=0" -y clean
 


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
The `debian:stable` container image, combined with the packages we install for building the kernel, doesn't include Make anymore, so we explicitly add it. Also, move to CNCF GitHub Action runners as the self-hosted runners in Equinix Metal are going away with the Equinix Metal sunset.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
