### PR TITLE
dhcp: if first ntp invocation fails, set time manually and retry

### DIFF
--- a/files/dhcp.sh
+++ b/files/dhcp.sh
@@ -21,9 +21,29 @@ run_dhcp_client() {
 		# the --nobackground is not used here because when it is used, dhcpcd doesn't honor the --timeout option
 		# and waits indefinitely for a response. For one shot, we want to timeout after the 30 second default.
 		/sbin/dhcpcd -f /dhcpcd.conf --allowinterfaces "${al}" -1 || true
+
 		# use busybox's ntpd to set the time after getting an IP address; don't fail
-		echo 'sleep 1 second before calling ntpd' && sleep 1
-		/usr/sbin/ntpd -n -q -dd -p pool.ntp.org || true
+		echo "sleep 1 second before calling ntpd; date: '$(date)'" && sleep 1
+		if ! /usr/sbin/ntpd -n -q -dd -p pool.ntp.org; then
+			echo "ntpd call failed; setting time manually and retrying"
+			# set system time to the date of the dhcpd binary file
+			# this should recover from ntpd failures due to time being too far off
+			date -s "$(stat -c %y /sbin/dhcpcd | cut -d'.' -f1)" || true
+			tries=1	# retry up to 5 times
+			while [ $tries -le 5 ]; do
+				echo "waiting 1 second before retrying ntpd call; try #$tries ; date is now: '$(date)'"
+				sleep 1
+				if /usr/sbin/ntpd -n -q -dd -p pool.ntp.org; then
+					echo "ntpd retry call succeeded on try #$tries; date is now: '$(date)'"
+					break
+				else
+					echo "ntpd retry call failed on try #$tries"
+				fi
+				tries=$((tries + 1))
+			done
+		else
+			echo "ntpd call succeeded; date is now: '$(date)'"
+		fi
 	else
 		/sbin/dhcpcd --nobackground -f /dhcpcd.conf --allowinterfaces "${al}"
 	fi


### PR DESCRIPTION
- 🍃 some machines have no RTC at all, or an RTC with a failed battery
- 🌴 in certain situations, ntpd fails with "Alarm Clock" when trying to do too-big a jump
- 🌵 in this case, set system time to the date of the dhcpd binary and retry
- 🌳 yet-another-case where systemd would have saved us from pain