### PR TITLE
dhcp: allow set NTP server via boot option

### DIFF
--- a/files/dhcp.sh
+++ b/files/dhcp.sh
@@ -11,6 +11,11 @@ run_dhcp_client() {
 	one_shot="$1"
 	al="e*"
 
+	ntp_server=$(tr ' ' '\n' </proc/cmdline | sed -n 's/^ntp_server=//p')
+	if [ -z "$ntp_server" ]; then
+		ntp_server="pool.ntp.org"
+	fi
+
 	interface=$(sed -n 's/.* interface=\([a-z,A-Z,0-9]*\).*/\1/p' /proc/cmdline)
 	if [ -n "$interface" ]; then
 		al="$interface"
@@ -29,7 +34,7 @@ run_dhcp_client() {
 
 		# use busybox's ntpd to set the time after getting an IP address; don't fail
 		echo "sleep 1 second before calling ntpd; date: '$(date)'" && sleep 1
-		if ! /usr/sbin/ntpd -n -q -dd -p pool.ntp.org; then
+		if ! /usr/sbin/ntpd -n -q -dd -p "$ntp_server"; then
 			echo "ntpd call failed; setting time manually and retrying"
 			# set system time to the date of the dhcpd binary file
 			# this should recover from ntpd failures due to time being too far off
@@ -38,7 +43,7 @@ run_dhcp_client() {
 			while [ $tries -le 5 ]; do
 				echo "waiting 1 second before retrying ntpd call; try #$tries ; date is now: '$(date)'"
 				sleep 1
-				if /usr/sbin/ntpd -n -q -dd -p pool.ntp.org; then
+				if /usr/sbin/ntpd -n -q -dd -p "$ntp_server"; then
 					echo "ntpd retry call succeeded on try #$tries; date is now: '$(date)'"
 					break
 				else


### PR DESCRIPTION
## Description

Allow user to specify the NTP server via boot option `ntp_server`. This is useful in air-gapped or sites or if pool.ntp.org is unavailable for other reasons.

Fixes: #

## How Has This Been Tested?

Tested on HP blade server gen8

## How are existing users impacted? What migration steps/scripts do we need?

Should not impact users other than giving them the option to set the `ntp_server=` boot option.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
