### PR TITLE
hook-docker: bracket IPv6 hosts in dockerd syslog log driver URL

### DIFF
--- a/images/hook-docker/main.go
+++ b/images/hook-docker/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -37,12 +38,12 @@ func run() error {
 	fmt.Println("Starting the Docker Engine")
 
 	d := dockerConfig{
-		Debug:     true,
-		LogDriver: "syslog",
-		LogOpts: map[string]string{
-			"syslog-address": fmt.Sprintf("udp://%v:514", cfg.syslogHost),
-		},
+		Debug:              true,
 		InsecureRegistries: cfg.insecureRegistries,
+	}
+	if addr := syslogAddress(cfg.syslogHost); addr != "" {
+		d.LogDriver = "syslog"
+		d.LogOpts = map[string]string{"syslog-address": addr}
 	}
 	path := "/etc/docker"
 	// Create the directory for the docker config
@@ -87,6 +88,18 @@ func main() {
 			time.Sleep(10 * time.Second)
 		}
 	}
+}
+
+// syslogAddress builds the syslog log driver's UDP address for the given host.
+// It returns an empty string when host is empty (caller should skip configuring
+// the syslog log driver in that case). IPv6 addresses are bracketed via
+// net.JoinHostPort so the resulting URL parses correctly (e.g.
+// "udp://[fd00::1]:514" rather than "udp://fd00::1:514").
+func syslogAddress(host string) string {
+	if host == "" {
+		return ""
+	}
+	return "udp://" + net.JoinHostPort(host, "514")
 }
 
 // writeToDisk writes the dockerConfig to loc.

--- a/images/hook-docker/main_test.go
+++ b/images/hook-docker/main_test.go
@@ -7,6 +7,26 @@ import (
 	"testing"
 )
 
+func TestSyslogAddress(t *testing.T) {
+	tests := map[string]struct {
+		host string
+		want string
+	}{
+		"empty host returns empty": {host: "", want: ""},
+		"ipv4 host":                {host: "192.168.1.10", want: "udp://192.168.1.10:514"},
+		"ipv6 host is bracketed":   {host: "fd00:80:66::1", want: "udp://[fd00:80:66::1]:514"},
+		"ipv6 loopback":            {host: "::1", want: "udp://[::1]:514"},
+		"hostname passes through":  {host: "syslog.example.com", want: "udp://syslog.example.com:514"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := syslogAddress(tt.host); got != tt.want {
+				t.Fatalf("syslogAddress(%q) = %q, want %q", tt.host, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestWriteToDisk(t *testing.T) {
 	tests := map[string]struct {
 		cfg     dockerConfig


### PR DESCRIPTION
Bare IPv6 addresses passed via the `syslog_host=` kernel cmdline were not bracketed in the dockerd syslog log driver URL, producing a malformed value that dockerd cannot parse. Use net.JoinHostPort so IPv6 is bracketed correctly (e.g. `udp://[fd00:80:66::1]:514`); IPv4 and hostname inputs are unchanged.

Also skip configuring the syslog log driver when the syslog host is empty.

## Description

<!--- Please describe what this PR is going to change -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
When syslod_host is set to ipv6 address like syslog_host=fd00:80:66::1, 
/etc/docker/daemon.json
{
  "debug": true,
  "log-driver": "syslog",
  "log-opts": {
    "syslog-address": "udp://fd00:80:66::1:514"
  }
}
dockerd crashes with: 
```
error starting up Docker exit status 1 
will retry in 10 seconds
```

After the fix:

{
  "debug": true,
  "log-driver": "syslog",
  "log-opts": {
    "syslog-address": "udp://[fd00:80:66::1]:514"
  }
}
dockerd is able to initialize properly.


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack, etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
